### PR TITLE
home 기능 구현

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/api/Constants.kt
+++ b/app/src/main/java/kr/sparta/tripmate/api/Constants.kt
@@ -5,4 +5,7 @@ object Constants {
     const val client_id = ""
     const val client_secret = ""
 
+    var EMPTYTYPE = 0
+    var SCRAPTYPE = 1
+
 }

--- a/app/src/main/java/kr/sparta/tripmate/data/model/home/HomeScrapData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/model/home/HomeScrapData.kt
@@ -1,0 +1,17 @@
+package kr.sparta.tripmate.data.model.home
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+@Parcelize
+data class HomeScrapData(
+    val type: Int,
+    val title: String,
+    val url: String,
+    val description: String,
+    val bloggername: String,
+    val bloggerlink: String,
+    val postdate: String,
+    var isLike:Boolean = false
+) : Parcelable{
+    constructor() : this(0,"", "", "", "", "", "", false)
+}

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/home/HomeFirstRepositorylmpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/home/HomeFirstRepositorylmpl.kt
@@ -1,0 +1,42 @@
+package kr.sparta.tripmate.data.repository.home
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import kr.sparta.tripmate.data.model.home.HomeScrapData
+import kr.sparta.tripmate.domain.model.ScrapModel
+import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
+
+
+class HomeFirstRepositorylmpl() {
+    private val databaseReference: DatabaseReference = FirebaseDatabase.getInstance().reference
+    fun getData(uid:String): LiveData<MutableList<ScrapModel>> {
+        val firstData = MutableLiveData<MutableList<ScrapModel>>()
+
+        val dataListener = object : ValueEventListener {
+            override fun onDataChange(snapshot: DataSnapshot) {
+                if (snapshot.exists()) {
+                    val homeScrapDataList = mutableListOf<ScrapModel>()
+                    for (dataSnapshot in snapshot.children) {
+                        val homeScrapData = dataSnapshot.getValue(ScrapModel::class.java)
+                        homeScrapData?.let { homeScrapDataList.add(it) }
+                    }
+                    firstData.value = homeScrapDataList
+                } else firstData.value = mutableListOf()
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+                firstData.value = mutableListOf()
+            }
+        }
+
+        databaseReference.child("scrapData").child(uid).addValueEventListener(dataListener)
+
+        return firstData
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/UserData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/UserData.kt
@@ -1,8 +1,8 @@
 package kr.sparta.tripmate.domain.model
 
 data class UserData(
-    var login_Id: String,
-    var login_NickName:String,
-    var login_profile:String,
-    var login_Uid:String
+    val login_Id: String,
+    val login_NickName:String,
+    val login_profile:String,
+    val login_Uid:String
 )

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeAdapter.kt
@@ -1,4 +1,0 @@
-package kr.sparta.tripmate.ui.home
-
-class HomeAdapter {
-}

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFirstAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFirstAdapter.kt
@@ -7,7 +7,9 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import kr.sparta.tripmate.R
+import kr.sparta.tripmate.api.Constants
 import kr.sparta.tripmate.databinding.EmptyViewBinding
+import kr.sparta.tripmate.databinding.HomeFirstItemsBinding
 import kr.sparta.tripmate.databinding.ScraptitemsBinding
 import kr.sparta.tripmate.domain.model.ScrapModel
 import kr.sparta.tripmate.util.method.removeHtmlTags
@@ -23,19 +25,16 @@ class HomeFirstAdapter(private val onItemClick: (ScrapModel, Int) -> Unit) :
             override fun areContentsTheSame(oldItem: ScrapModel, newItem: ScrapModel): Boolean {
                 return oldItem == newItem
             }
-
         }
     ) {
 
-    inner class FirstViewHolder(private val binding: ScraptitemsBinding) : RecyclerView.ViewHolder
+    inner class FirstViewHolder(private val binding: HomeFirstItemsBinding) : RecyclerView.ViewHolder
         (binding.root) {
         fun bind(items: ScrapModel) = with(binding) {
-            Log.d("TripMates","홈 아이템:${items}")
-            Log.d("TripMates","홈 아이템:${items.title}")
-            Log.d("TripMates", "홈아이템:${items.description}")
-            scrapTitle.text = removeHtmlTags(items.title)
-            scrapContent.text = removeHtmlTags(items.description)
-            scrapImage.setImageResource(R.drawable.blogimage)
+            Log.d("TripMates", "뷰홀더에 항목${items}")
+            homeFirstTitle.text = removeHtmlTags(items.title)
+            homeFirstContent.text = removeHtmlTags(items.description)
+            homeFirstImage.setImageResource(R.drawable.blogimage)
 
             itemView.setOnClickListener {
                 onItemClick(items, bindingAdapterPosition)
@@ -43,22 +42,53 @@ class HomeFirstAdapter(private val onItemClick: (ScrapModel, Int) -> Unit) :
         }
     }
 
-    inner class SecondViewHolder(private val binding: EmptyViewBinding) : RecyclerView.ViewHolder
+    inner class EmptyViewHolder(private val binding: EmptyViewBinding) : RecyclerView.ViewHolder
         (binding.root) {
         fun bind() {
+            Log.d("TripMates","빈텍스트 호출되고있냐?")
             binding.emptyTextView.text = "결과가 없습니다."
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val binding = ScraptitemsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return FirstViewHolder(binding)
+        return when (viewType) {
+            Constants.EMPTYTYPE -> {
+                val binding = EmptyViewBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent, false
+                )
+                EmptyViewHolder(binding)
+            }
+
+            else -> {
+                val binding =
+                    HomeFirstItemsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                FirstViewHolder(binding)
+            }
+        }
     }
 
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        holder as FirstViewHolder
-        Log.d("TripMates","어댑터 position${position}")
-        holder.bind(getItem(position))
+
+        when (holder.itemViewType) {
+            Constants.EMPTYTYPE -> {
+                holder as EmptyViewHolder
+                holder.bind()
+            }
+
+            Constants.SCRAPTYPE -> {
+                holder as FirstViewHolder
+                holder.bind(getItem(position))
+            }
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return if (getItem(position) is ScrapModel) {
+            Constants.SCRAPTYPE
+        } else {
+            Constants.EMPTYTYPE
+        }
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFirstAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFirstAdapter.kt
@@ -1,0 +1,64 @@
+package kr.sparta.tripmate.ui.home
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import kr.sparta.tripmate.R
+import kr.sparta.tripmate.databinding.EmptyViewBinding
+import kr.sparta.tripmate.databinding.ScraptitemsBinding
+import kr.sparta.tripmate.domain.model.ScrapModel
+import kr.sparta.tripmate.util.method.removeHtmlTags
+
+class HomeFirstAdapter(private val onItemClick: (ScrapModel, Int) -> Unit) :
+    ListAdapter<ScrapModel,
+            RecyclerView.ViewHolder>(
+        object : DiffUtil.ItemCallback<ScrapModel>() {
+            override fun areItemsTheSame(oldItem: ScrapModel, newItem: ScrapModel): Boolean {
+                return oldItem.url == newItem.url
+            }
+
+            override fun areContentsTheSame(oldItem: ScrapModel, newItem: ScrapModel): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    ) {
+
+    inner class FirstViewHolder(private val binding: ScraptitemsBinding) : RecyclerView.ViewHolder
+        (binding.root) {
+        fun bind(items: ScrapModel) = with(binding) {
+            Log.d("TripMates","홈 아이템:${items}")
+            Log.d("TripMates","홈 아이템:${items.title}")
+            Log.d("TripMates", "홈아이템:${items.description}")
+            scrapTitle.text = removeHtmlTags(items.title)
+            scrapContent.text = removeHtmlTags(items.description)
+            scrapImage.setImageResource(R.drawable.blogimage)
+
+            itemView.setOnClickListener {
+                onItemClick(items, bindingAdapterPosition)
+            }
+        }
+    }
+
+    inner class SecondViewHolder(private val binding: EmptyViewBinding) : RecyclerView.ViewHolder
+        (binding.root) {
+        fun bind() {
+            binding.emptyTextView.text = "결과가 없습니다."
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val binding = ScraptitemsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return FirstViewHolder(binding)
+    }
+
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        holder as FirstViewHolder
+        Log.d("TripMates","어댑터 position${position}")
+        holder.bind(getItem(position))
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -6,18 +6,24 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
-import kr.sparta.tripmate.R
 import kr.sparta.tripmate.databinding.FragmentHomeBinding
 import kr.sparta.tripmate.ui.main.MainActivity
+import kr.sparta.tripmate.ui.scrap.ScrapDetail
+import kr.sparta.tripmate.ui.viewmodel.home.FirstViewModel
 import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
 
 class HomeFragment : Fragment() {
     private val binding by lazy { FragmentHomeBinding.inflate(layoutInflater) }
+    private val firstViewModel: FirstViewModel by viewModels()
+    private lateinit var homeFirstAdapter: HomeFirstAdapter
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
     }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -28,8 +34,37 @@ class HomeFragment : Fragment() {
         clickedCommu()
         clickedBudget()
 
+        homeView()
+
         return binding.root
     }
+
+    private fun homeView() {
+        homeFirstAdapter = HomeFirstAdapter(
+            onItemClick = { model, position ->
+                val intent = ScrapDetail.newIntentForScrap(requireContext(), model)
+            }
+        )
+        binding.homeRecyclerView1.apply {
+            layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+            adapter = homeFirstAdapter
+            setHasFixedSize(true)
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        firstViewModel.apply {
+            getFirstData(SharedPreferences.getUid(requireContext())).observe(viewLifecycleOwner) {
+                homeFirstAdapter.submitList(it)
+            }
+        }
+    }
+
 
     private fun clickedBudget() {
         binding.homeArrow3.setOnClickListener {
@@ -48,6 +83,7 @@ class HomeFragment : Fragment() {
             (context as MainActivity).onScrapClicked()
         }
     }
+
     private fun clickedProfile() {
         binding.homeProfileImage.setOnClickListener {
             (context as MainActivity).onMyPageClicked()

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -6,6 +6,8 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
@@ -20,6 +22,10 @@ class HomeFragment : Fragment() {
     private val firstViewModel: FirstViewModel by viewModels()
     private lateinit var homeFirstAdapter: HomeFirstAdapter
 
+    private val homeResults = registerForActivityResult(ActivityResultContracts
+        .StartActivityForResult()){
+        if(it.resultCode == AppCompatActivity.RESULT_OK){}
+    }
     override fun onAttach(context: Context) {
         super.onAttach(context)
     }
@@ -43,6 +49,7 @@ class HomeFragment : Fragment() {
         homeFirstAdapter = HomeFirstAdapter(
             onItemClick = { model, position ->
                 val intent = ScrapDetail.newIntentForScrap(requireContext(), model)
+                homeResults.launch(intent)
             }
         )
         binding.homeRecyclerView1.apply {

--- a/app/src/main/java/kr/sparta/tripmate/ui/scrap/ScrapAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/scrap/ScrapAdapter.kt
@@ -38,7 +38,6 @@ class ScrapAdapter(
             }
             scrapLike.setOnClickListener {
                 onLikeClick(items, bindingAdapterPosition)
-              scrapLike.likeChange(items.isLike)
             }
             scrapLike.likeChange(items.isLike)
         }

--- a/app/src/main/java/kr/sparta/tripmate/ui/scrap/ScrapFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/scrap/ScrapFragment.kt
@@ -76,11 +76,17 @@ class ScrapFragment : Fragment() {
                 scrapResults.launch(intent)
             },
             onLikeClick = { model, position ->
-                model.isLike = !model.isLike
 
+                scrapViewModel.updateIsLike(
+                    model = model.copy(
+                        isLike = !model.isLike
+                    ),
+                    position
+                )
+                //위에서 model의 isLike값을 반전시키고 뷰모델에서 업데이트되기때문에 아래의 model.isLike는 값이 반전되기 이전이다.
                 if (model.isLike) {
-                    saveScrapFirebase(model)
-                } else deleteScrapFirebase(model)
+                    deleteScrapFirebase(model)
+                } else saveScrapFirebase(model)
             }
         )
 

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/FirstViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/FirstViewModel.kt
@@ -1,0 +1,16 @@
+package kr.sparta.tripmate.ui.viewmodel.home
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import kr.sparta.tripmate.data.repository.home.HomeFirstRepositorylmpl
+import kr.sparta.tripmate.domain.model.ScrapModel
+
+class FirstViewModel() : ViewModel() {
+    private val homeRepository = HomeFirstRepositorylmpl()
+
+    fun getFirstData(uid:String): LiveData<MutableList<ScrapModel>> {
+        return homeRepository.getData(uid)
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/HomeFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/HomeFactory.kt
@@ -1,4 +1,0 @@
-package kr.sparta.tripmate.ui.viewmodel.home
-
-class HomeFactory {
-}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/HomeViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/HomeViewModel.kt
@@ -1,4 +1,0 @@
-package kr.sparta.tripmate.ui.viewmodel.home
-
-class HomeViewModel {
-}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/scrap/ScrapViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/scrap/ScrapViewModel.kt
@@ -84,4 +84,12 @@ class ScrapViewModel(private val searchBlog: GetSearchBlogUseCase) : ViewModel()
             }
         }
     }
+
+    fun updateIsLike(model: ScrapModel, position: Int) {
+        //or.Empty() : 해당값이 null일때 빈 리스트를 반환해준다.
+        val list = scrapResult.value.orEmpty().toMutableList()
+        list.find { it.url == model.url } ?: return
+        list[position] = model
+        _scrapResult.value = list
+    }
 }

--- a/app/src/main/res/layout/empty_view.xml
+++ b/app/src/main/res/layout/empty_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/emptyTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/empty_view"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -99,21 +99,12 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/home_recyclerView1"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="200dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/home_view1" />
 
-            <ProgressBar
-                android:id="@+id/home_loading"
-                style="?android:attr/progressBarStyleLarge"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:layout_constraintBottom_toTopOf="@+id/home_recyclerView2"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/home_view1" />
+
 
             <TextView
                 android:id="@+id/home_title2"
@@ -149,7 +140,7 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/home_recyclerView2"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="200dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/home_view2" />
@@ -188,7 +179,7 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/home_recyclerView3"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="200dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/home_view3" />

--- a/app/src/main/res/layout/home_first_items.xml
+++ b/app/src/main/res/layout/home_first_items.xml
@@ -1,0 +1,48 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/home_first_Grid_layout"
+    android:layout_width="190dp"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:layout_margin="10dp"
+    android:orientation="vertical">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/home_first_type_iconCardView"
+        android:layout_width="115dp"
+        android:layout_height="115dp"
+        android:layout_gravity="center"
+        app:cardCornerRadius="35dp"
+        app:cardElevation="0dp">
+
+        <ImageView
+            android:id="@+id/home_first_image"
+            android:layout_width="115dp"
+            android:layout_height="115dp"
+            android:scaleType="centerCrop" />
+
+    </androidx.cardview.widget.CardView>
+
+
+    <TextView
+        android:id="@+id/home_first_title"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="10dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="@color/black"
+        android:textSize="15sp" />
+
+
+    <TextView
+        android:id="@+id/home_first_content"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textColor="@color/black"
+        android:textSize="12sp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,5 @@
     <string name="procedure_time_text">시간</string>
     <string name="procedure_memo_text">메모</string>
     <string name="budget_category_input_name">카테고리 이름을 입력해 주세요</string>
+    <string name="empty_view">결과가 없습니다.</string>
 </resources>


### PR DESCRIPTION
## 📌Linked Issues
  
- #62 

## ✏Change Details

- Scrap에서 북마크 추가된데이터를 파이어베이스에 저장하고 실시간으로 home 첫번쨰줄 화면에 표시합니다. ( 추가&삭제 모두 실시간 갱신됩니다.)
- 아이템 클릭 시 해당 블로그로 이동됩니다.
- 레파지토리(라이브데이터적용) - 뷰모델 - 프래그먼트 형식입니다.
## 💬Comment

- home에서 추가&삭제는 아직 구현하지않았습니다.
- **레파지토리를 만들기는 했는데 저렇게 하는게 맞는지 피드백 부탁드려요**
- **내가 잘못한건지 ListViewAdapter의 뷰타입 방식이 다른건지 현재 아이템이 비었을때 텍스트뷰 표시가 안됩니다. (해당 뷰홀더 로그자체가안뜨는거보면 데이터가없는거같은데 적용안됩니다. 확인 부탁드려요)**

## 📑References



## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
