### PR TITLE
mypage 북마크 기능

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/BookmarkFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/BookmarkFragment.kt
@@ -5,17 +5,33 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
 import kr.sparta.tripmate.databinding.FragmentBookmarkBinding
+import kr.sparta.tripmate.ui.scrap.ScrapDetail
+import kr.sparta.tripmate.ui.viewmodel.home.FirstViewModel
+import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
 
 class BookmarkFragment : Fragment() {
     companion object {
         fun newInstance(): BookmarkFragment = BookmarkFragment()
     }
+    private val bookmarkResults = registerForActivityResult(ActivityResultContracts
+        .StartActivityForResult()){
+        if(it.resultCode == AppCompatActivity.RESULT_OK){}
+    }
 
-    private var _binding : FragmentBookmarkBinding? = null
+    private val scrapViewModel: FirstViewModel by viewModels()
+    private var _binding: FragmentBookmarkBinding? = null
     private val binding get() = _binding!!
-    private val adapter by lazy {
-        BookmarkListAdapter()
+    private val bookmarkAdapter by lazy {
+        BookmarkListAdapter(
+            onItemClick = { model, position ->
+                bookmarkResults.launch(ScrapDetail.newIntentForScrap(requireContext(), model))
+            }
+        )
     }
 
     override fun onCreateView(
@@ -30,10 +46,22 @@ class BookmarkFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         initView()
+        initViewModel()
     }
 
-    private fun initView()=with(binding) {
-        bookmarkRecyclerview.adapter = adapter
-        bookmarkRecyclerview.setHasFixedSize(true)
+    private fun initViewModel() {
+        with(scrapViewModel) {
+            getFirstData(SharedPreferences.getUid(requireContext())).observe(viewLifecycleOwner){
+                bookmarkAdapter.submitList(it)
+            }
+        }
+    }
+
+    private fun initView() = with(binding) {
+      bookmarkRecyclerview.apply {
+          layoutManager = GridLayoutManager(requireContext(),2)
+          adapter = bookmarkAdapter
+          setHasFixedSize(true)
+      }
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/BookmarkListAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/BookmarkListAdapter.kt
@@ -11,19 +11,28 @@ import com.bumptech.glide.Glide
 import kr.sparta.tripmate.R
 import kr.sparta.tripmate.databinding.FragmentMypageBoardItemBinding
 import kr.sparta.tripmate.databinding.FragmentMypageBookmarkItemBinding
+import kr.sparta.tripmate.domain.model.ScrapModel
 
-class BookmarkListAdapter:ListAdapter<BookmarkModel, BookmarkListAdapter.Holder>(object: DiffUtil.ItemCallback<BookmarkModel>() {
-    override fun areItemsTheSame(oldItem: BookmarkModel, newItem: BookmarkModel): Boolean {
-        return oldItem.url == newItem.url
-    }
+class BookmarkListAdapter(private val onItemClick: (ScrapModel, Int) -> Unit) :
+    ListAdapter<ScrapModel,
+            BookmarkListAdapter
+            .Holder>(object :
+        DiffUtil.ItemCallback<ScrapModel>() {
+        override fun areItemsTheSame(oldItem: ScrapModel, newItem: ScrapModel): Boolean {
+            return oldItem.url == newItem.url
+        }
 
-    override fun areContentsTheSame(oldItem: BookmarkModel, newItem: BookmarkModel): Boolean {
-        return oldItem == newItem
-    }
+        override fun areContentsTheSame(oldItem: ScrapModel, newItem: ScrapModel): Boolean {
+            return oldItem == newItem
+        }
 
-}) {
+    }) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
-        val view = FragmentMypageBookmarkItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val view = FragmentMypageBookmarkItemBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
         return Holder(view)
     }
 
@@ -31,11 +40,16 @@ class BookmarkListAdapter:ListAdapter<BookmarkModel, BookmarkListAdapter.Holder>
         return holder.bind(getItem(position))
     }
 
-    class Holder(private val binding: FragmentMypageBookmarkItemBinding): RecyclerView.ViewHolder(binding.root){
-        fun bind(item : BookmarkModel)=with(binding) {
+    inner class Holder(private val binding: FragmentMypageBookmarkItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: ScrapModel) = with(binding) {
             bookmarkImage.setImageResource(R.drawable.blogimage)
             bookmarkTitle.text = item.title
             bookmarkContent.text = item.description
+
+            itemView.setOnClickListener {
+                onItemClick(item, bindingAdapterPosition)
+            }
         }
     }
 }


### PR DESCRIPTION
## 📌Linked Issues

-  #75 

## ✏Change Details

- scrap에서 데이터베이스에 북마크 저장한 데이터를 가로 리사이클러뷰로 표시해줍니다.
- 데이터베이스 아이템 삭제&추가 실시간 갱신되어 화면에 표시됩니다.
- 아이템 클릭 시 해당 블로그로 이동 됩니다.

## 💬Comment

- mypage에서 아이템 추가&삭제는 아직 구현하지않았습니다.
- 기존에 작성하신코드는 최대한 건드리지 않았습니다. (어쩔 수 없는 부분만 건듬)

## 📑References


## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
