### PR TITLE
Home& MyPage 에서 아이템을 클릭 시 동일하게 조회수가 1씩 오르게 적용했습니다.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:name=".ui.budget.ProcedureDetailActivity"
             android:exported="false" />
         <activity
-            android:name=".ui.budget.BudgetDetailActivity"
+            android:name=".ui.budget.detail.main.BudgetDetailActivity"
             android:exported="false" />
         <activity
             android:name=".ui.budget.BudgetContentActivity"

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/FirebaseBoardRepositoryImpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/FirebaseBoardRepositoryImpl.kt
@@ -2,17 +2,26 @@ package kr.sparta.tripmate.data.repository
 
 import androidx.lifecycle.MutableLiveData
 import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
+import kr.sparta.tripmate.data.model.community.CommunityModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 
 class FirebaseBoardRepositoryImpl(
     private val
     remoteSource: FirebaseDBRemoteDataSource
-):FirebaseBoardRepository {
+) : FirebaseBoardRepository {
     override fun getFirebaseBoardData(
         uid: String,
         boardLiveData: MutableLiveData<List<CommunityModelEntity?>>
     ) {
         remoteSource.getFirebaseBoardData(uid, boardLiveData)
+    }
+
+    override fun isCommuView(
+        model: CommunityModel,
+        position: Int,
+        commuLiveData: MutableLiveData<List<CommunityModelEntity?>>
+    ) {
+        remoteSource.updateCommuView(model, position, commuLiveData)
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/repository/FirebaseBoardRepository.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/repository/FirebaseBoardRepository.kt
@@ -1,10 +1,15 @@
 package kr.sparta.tripmate.domain.repository
 
 import androidx.lifecycle.MutableLiveData
+import kr.sparta.tripmate.data.model.community.CommunityModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 
 interface FirebaseBoardRepository {
     fun getFirebaseBoardData(
         uid: String, boardLiveData : MutableLiveData<List<CommunityModelEntity?>>
+    )
+    fun isCommuView(
+        model: CommunityModel, position: Int, commuLiveData:
+        MutableLiveData<List<CommunityModelEntity?>>
     )
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/IsFirebaseBoardViews.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/IsFirebaseBoardViews.kt
@@ -1,0 +1,12 @@
+package kr.sparta.tripmate.domain.usecase
+
+import androidx.lifecycle.MutableLiveData
+import kr.sparta.tripmate.data.model.community.CommunityModel
+import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
+import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
+
+class IsFirebaseBoardViews(private val repository:FirebaseBoardRepository) {
+    operator fun invoke(model: CommunityModel, position: Int, commuLiveData:
+    MutableLiveData<List<CommunityModelEntity?>>
+    ) = repository.isCommuView(model, position, commuLiveData)
+}

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/IsViewsFirebaseBoardData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/IsViewsFirebaseBoardData.kt
@@ -5,7 +5,7 @@ import kr.sparta.tripmate.data.model.community.CommunityModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 
-class IsFirebaseBoardViews(private val repository:FirebaseBoardRepository) {
+class IsViewsFirebaseBoardData(private val repository:FirebaseBoardRepository) {
     operator fun invoke(model: CommunityModel, position: Int, commuLiveData:
     MutableLiveData<List<CommunityModelEntity?>>
     ) = repository.isCommuView(model, position, commuLiveData)

--- a/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityDetailActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityDetailActivity.kt
@@ -38,5 +38,7 @@ class CommunityDetailActivity : AppCompatActivity() {
         binding.communityTvDetailDescription.text = writeItem.body
         binding.communityTvDetailUsername.text = writeItem.profileNickname
         binding.communityIvAddImage.load(writeItem.addedImage)
+        binding.communityDetailLikecount.text = writeItem.likes
+        binding.communityTvDetailViewcount.text = writeItem.views
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -79,6 +79,7 @@ class HomeFragment : Fragment() {
                 val intent = Intent(homeContext, CommunityDetailActivity::class.java)
                 intent.putExtra("Data", model)
                 homeResults.launch(intent)
+                homeBoardViewModel.viewHomeBoardData(model,position)
             }
         )
         binding.homeRecyclerView2.apply {
@@ -140,6 +141,7 @@ class HomeFragment : Fragment() {
         val uid = SharedPreferences.getUid(homeContext)
         homeScrapViewModel.updateScrapData(homeContext)
         homeBoardViewModel.getHomeBoardData(uid)
+
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/board/BoardFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/board/BoardFragment.kt
@@ -42,6 +42,7 @@ class BoardFragment : Fragment() {
                 val intent = Intent(boardContext, CommunityDetailActivity::class.java)
                 intent.putExtra("Data", model)
                 boardResurlts.launch(intent)
+                boardViewModel.viewMyPageBoardData(model,position)
             }
         )
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardFactory.kt
@@ -6,16 +6,21 @@ import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
 import kr.sparta.tripmate.data.repository.FirebaseBoardRepositoryImpl
 import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.usecase.GetFirebaseBoardData
+import kr.sparta.tripmate.domain.usecase.IsFirebaseBoardViews
 
 class HomeBoardFactory : ViewModelProvider.Factory {
-    private val repository : FirebaseBoardRepository by lazy{FirebaseBoardRepositoryImpl(
-        FirebaseDBRemoteDataSource()
-    )}
+    private val repository: FirebaseBoardRepository by lazy {
+        FirebaseBoardRepositoryImpl(
+            FirebaseDBRemoteDataSource()
+        )
+    }
+
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        if (modelClass.isAssignableFrom(HomeBoardViewModel::class.java)){
+        if (modelClass.isAssignableFrom(HomeBoardViewModel::class.java)) {
             return HomeBoardViewModel(
-                GetFirebaseBoardData(repository)
-            )as T
+                GetFirebaseBoardData(repository),
+                IsFirebaseBoardViews(repository)
+            ) as T
         }
         throw IllegalArgumentException("에러")
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardFactory.kt
@@ -6,7 +6,7 @@ import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
 import kr.sparta.tripmate.data.repository.FirebaseBoardRepositoryImpl
 import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.usecase.GetFirebaseBoardData
-import kr.sparta.tripmate.domain.usecase.IsFirebaseBoardViews
+import kr.sparta.tripmate.domain.usecase.IsViewsFirebaseBoardData
 
 class HomeBoardFactory : ViewModelProvider.Factory {
     private val repository: FirebaseBoardRepository by lazy {
@@ -19,7 +19,7 @@ class HomeBoardFactory : ViewModelProvider.Factory {
         if (modelClass.isAssignableFrom(HomeBoardViewModel::class.java)) {
             return HomeBoardViewModel(
                 GetFirebaseBoardData(repository),
-                IsFirebaseBoardViews(repository)
+                IsViewsFirebaseBoardData(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardViewModel.kt
@@ -3,13 +3,22 @@ package kr.sparta.tripmate.ui.viewmodel.home.board
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
+import kr.sparta.tripmate.domain.model.firebase.toCommunity
 import kr.sparta.tripmate.domain.usecase.GetFirebaseBoardData
+import kr.sparta.tripmate.domain.usecase.IsFirebaseBoardViews
 
-class HomeBoardViewModel(private val getFirebaseBoardData: GetFirebaseBoardData) : ViewModel() {
+class HomeBoardViewModel(private val getFirebaseBoardData: GetFirebaseBoardData, private val
+isFirebaseBoardViews: IsFirebaseBoardViews
+) :
+    ViewModel
+    () {
     private val _homeBoard: MutableLiveData<List<CommunityModelEntity?>> = MutableLiveData()
     val homeBoard get() = _homeBoard
 
     fun getHomeBoardData(uid: String) {
         getFirebaseBoardData.invoke(uid, _homeBoard)
+    }
+    fun viewHomeBoardData(model:CommunityModelEntity,position:Int){
+        isFirebaseBoardViews.invoke(model.toCommunity(), position,_homeBoard)
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.ViewModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.model.firebase.toCommunity
 import kr.sparta.tripmate.domain.usecase.GetFirebaseBoardData
-import kr.sparta.tripmate.domain.usecase.IsFirebaseBoardViews
+import kr.sparta.tripmate.domain.usecase.IsViewsFirebaseBoardData
 
 class HomeBoardViewModel(private val getFirebaseBoardData: GetFirebaseBoardData, private val
-isFirebaseBoardViews: IsFirebaseBoardViews
+isViewsFirebaseBoardData: IsViewsFirebaseBoardData
 ) :
     ViewModel
     () {
@@ -19,6 +19,6 @@ isFirebaseBoardViews: IsFirebaseBoardViews
         getFirebaseBoardData.invoke(uid, _homeBoard)
     }
     fun viewHomeBoardData(model:CommunityModelEntity,position:Int){
-        isFirebaseBoardViews.invoke(model.toCommunity(), position,_homeBoard)
+        isViewsFirebaseBoardData.invoke(model.toCommunity(), position,_homeBoard)
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BoardFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BoardFactory.kt
@@ -6,6 +6,7 @@ import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
 import kr.sparta.tripmate.data.repository.FirebaseBoardRepositoryImpl
 import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.usecase.GetFirebaseBoardData
+import kr.sparta.tripmate.domain.usecase.IsViewsFirebaseBoardData
 
 class BoardFactory : ViewModelProvider.Factory {
     private val repository : FirebaseBoardRepository by lazy {
@@ -14,7 +15,8 @@ class BoardFactory : ViewModelProvider.Factory {
     override fun <T: ViewModel> create(modelClass: Class<T>) :T{
         if(modelClass.isAssignableFrom(BoardViewModel::class.java)){
             return BoardViewModel(
-                GetFirebaseBoardData(repository)
+                GetFirebaseBoardData(repository),
+                IsViewsFirebaseBoardData(repository)
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BoardViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BoardViewModel.kt
@@ -3,13 +3,23 @@ package kr.sparta.tripmate.ui.viewmodel.mypage
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
+import kr.sparta.tripmate.domain.model.firebase.toCommunity
 import kr.sparta.tripmate.domain.usecase.GetFirebaseBoardData
+import kr.sparta.tripmate.domain.usecase.IsViewsFirebaseBoardData
 
-class BoardViewModel(private val getFirebaseBoardData: GetFirebaseBoardData) : ViewModel() {
-    private val _myPage : MutableLiveData<List<CommunityModelEntity?>> = MutableLiveData()
+class BoardViewModel(
+    private val getFirebaseBoardData: GetFirebaseBoardData,
+    private val isViewsFirebaseBoardData: IsViewsFirebaseBoardData
+) :
+    ViewModel() {
+    private val _myPage: MutableLiveData<List<CommunityModelEntity?>> = MutableLiveData()
     val myPage get() = _myPage
 
-    fun getBoardData(uid:String){
-        getFirebaseBoardData.invoke(uid,_myPage)
+    fun getBoardData(uid: String) {
+        getFirebaseBoardData.invoke(uid, _myPage)
+    }
+
+    fun viewMyPageBoardData(model: CommunityModelEntity, position: Int) {
+        isViewsFirebaseBoardData.invoke(model.toCommunity(), position, _myPage)
     }
 }


### PR DESCRIPTION
## 📌Linked Issues

- #124 

## ✏Change Details

- 기존에 MyPage와 Home에서는 단순히 RDB의 데이터를 받아와서 앱에 표시했습니다.
- 그래서 MyPage와 Home에서 게시글을 클릭 시 조회수가 올라가지 않았었는데
동일하게 조회수가 추가되는것을 RDB에 적용했습니다.
- MVVM 구조로 분할했습니다.
- 데이터는 뷰모델&라이브데이터로 관리합니다.

## 💬Comment

- Actions의 빌드 실패는 중간에 manifests의 패키지 경로가 변경되있어서 수정했습니다.

## 📑References


## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
