### PR TITLE
mypage : User정보를 수정 후 RDB에 저장하고 업데이트 합니다. 

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/data/model/community/UserData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/model/community/UserData.kt
@@ -1,0 +1,9 @@
+package kr.sparta.tripmate.data.model.community
+
+data class UserData(
+    val login_Id: String? = null,       //로그인 id
+    val login_NickName: String? = null, //닉네임
+    val login_profile: String? = null,  //프로필사진
+    val login_Uid: String? = null,      //고유키값
+    val login_coment: String? = null    //자기소개
+)

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/FirebaseScrapRepositoryImpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/FirebaseScrapRepositoryImpl.kt
@@ -6,6 +6,7 @@ import kr.sparta.tripmate.data.model.community.CommunityModel
 import kr.sparta.tripmate.domain.model.firebase.BoardKeyModelEntity
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.model.firebase.ScrapEntity
+import kr.sparta.tripmate.domain.model.login.UserDataEntity
 import kr.sparta.tripmate.domain.model.scrap.toScrapModel
 import kr.sparta.tripmate.domain.repository.FirebaseScrapRepository
 
@@ -64,4 +65,19 @@ class FirebaseScrapRepositoryImpl(private val remoteSource: FirebaseDBRemoteData
     ) {
         remoteSource.getFirebaseBoardKeyData(uid, boardKeyLiveData)
     }
+
+    override fun updateUserData(
+        uid: String, userLiveData:
+        MutableLiveData<UserDataEntity?>
+    ) {
+        remoteSource.updateUserData(uid, userLiveData)
+    }
+
+    override fun saveUserData(
+        model: UserDataEntity,
+        userLiveData: MutableLiveData<UserDataEntity?>
+    ) {
+        remoteSource.saveUserData(model, userLiveData)
+    }
+
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/login/UserData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/login/UserData.kt
@@ -1,8 +1,0 @@
-package kr.sparta.tripmate.domain.model.login
-
-data class UserData(
-    val login_Id: String,
-    val login_NickName:String,
-    val login_profile:String,
-    val login_Uid:String
-)

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/login/UserDataEntity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/login/UserDataEntity.kt
@@ -1,0 +1,13 @@
+package kr.sparta.tripmate.domain.model.login
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class UserDataEntity(
+    val login_Id: String? = null,       //로그인 id
+    val login_NickName: String? = null, //닉네임
+    val login_profile: String? = null,  //프로필사진
+    val login_Uid: String? = null,      //고유키값
+    val login_coment: String? = null    //자기소개
+) : Parcelable

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/login/UserDataMapper.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/login/UserDataMapper.kt
@@ -1,0 +1,19 @@
+package kr.sparta.tripmate.domain.model.login
+
+import kr.sparta.tripmate.data.model.community.UserData
+
+fun UserData.toEntity() = UserDataEntity(
+    login_Id = login_Id,
+    login_NickName = login_NickName,
+    login_Uid = login_Uid,
+    login_profile = login_profile,
+    login_coment = login_coment
+)
+
+fun List<UserData>.toEntity() :List<UserDataEntity>{
+    val list = ArrayList<UserDataEntity>()
+    for(i in this.indices){
+        this[i]?.let { list.add(it.toEntity()) }
+    }
+    return list.toList()
+}

--- a/app/src/main/java/kr/sparta/tripmate/domain/repository/FirebaseScrapRepository.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/repository/FirebaseScrapRepository.kt
@@ -5,6 +5,7 @@ import kr.sparta.tripmate.data.model.community.CommunityModel
 import kr.sparta.tripmate.domain.model.firebase.BoardKeyModelEntity
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.model.firebase.ScrapEntity
+import kr.sparta.tripmate.domain.model.login.UserDataEntity
 
 /**
  * 작성자: 서정한
@@ -34,5 +35,13 @@ interface FirebaseScrapRepository {
     fun getFirebaseBoardKeyData(
         uid: String,
         boardKeyLiveData: MutableLiveData<List<BoardKeyModelEntity?>>
+    )
+
+    fun updateUserData(
+        uid: String, userLiveData: MutableLiveData<UserDataEntity?>
+    )
+
+    fun saveUserData(
+        model: UserDataEntity, userLiveData: MutableLiveData<UserDataEntity?>
     )
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebasescraprepository/SaveUserData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebasescraprepository/SaveUserData.kt
@@ -1,0 +1,11 @@
+package kr.sparta.tripmate.domain.usecase.firebasescraprepository
+
+import androidx.lifecycle.MutableLiveData
+import kr.sparta.tripmate.domain.model.login.UserDataEntity
+import kr.sparta.tripmate.domain.repository.FirebaseScrapRepository
+
+class SaveUserData(private val repository: FirebaseScrapRepository) {
+    operator fun invoke(model: UserDataEntity, userLiveData: MutableLiveData<UserDataEntity?>) {
+        repository.saveUserData(model, userLiveData)
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebasescraprepository/UpdateUserData.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebasescraprepository/UpdateUserData.kt
@@ -1,0 +1,13 @@
+package kr.sparta.tripmate.domain.usecase.firebasescraprepository
+
+import androidx.lifecycle.MutableLiveData
+import kr.sparta.tripmate.domain.model.login.UserDataEntity
+import kr.sparta.tripmate.domain.repository.FirebaseScrapRepository
+
+class UpdateUserData(private val repository: FirebaseScrapRepository) {
+    operator fun invoke(
+        uid: String, userLiveData:
+        MutableLiveData<UserDataEntity?>
+    ) =
+        repository.updateUserData(uid,userLiveData)
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
@@ -19,7 +19,7 @@ import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import kr.sparta.tripmate.R
 import kr.sparta.tripmate.databinding.ActivityLoginBinding
-import kr.sparta.tripmate.domain.model.login.UserData
+import kr.sparta.tripmate.domain.model.login.UserDataEntity
 import kr.sparta.tripmate.ui.main.MainActivity
 import kr.sparta.tripmate.util.method.longToast
 import kr.sparta.tripmate.util.method.shortToast
@@ -109,19 +109,25 @@ class LoginActivity : AppCompatActivity() {
             }
     }
 
-    private fun savedLogin(id: String, nickName: String, photoUrl: String, uid: String) {
+    private fun savedLogin(
+        id: String,
+        nickName: String,
+        photoUrl: String,
+        uid: String,
+        coment: String
+    ) {
         Log.d("TripMates", "아이디 : ${id}")
         Log.d("TripMates", "닉넴 : ${nickName}")
         login_Database.child("UserData").child(uid).setValue(
-            UserData(
+            UserDataEntity(
                 id, nickName, photoUrl,
-                uid
+                uid, coment
             )
         )
         SharedPreferences.apply {
-            saveUid(this@LoginActivity,uid)
-            saveProfile(this@LoginActivity,photoUrl)
-            saveNickName(this@LoginActivity,nickName)
+            saveUid(this@LoginActivity, uid)
+            saveProfile(this@LoginActivity, photoUrl)
+            saveNickName(this@LoginActivity, nickName)
         }
 
         startActivity(Intent(this, MainActivity::class.java))
@@ -150,7 +156,7 @@ class LoginActivity : AppCompatActivity() {
             longToast("${input_nickName}의 계정으로 로그인 되었습니다.")
             savedLogin(                                     //저장할 데이터들 함수로 보냄
                 user?.email.toString(), input_nickName,
-                user?.photoUrl?.toString() ?: "", user?.uid!!
+                user?.photoUrl?.toString() ?: "", user?.uid!!, ""
             )
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/MyPageFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/MyPageFactory.kt
@@ -1,0 +1,26 @@
+package kr.sparta.tripmate.ui.viewmodel.mypage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
+import kr.sparta.tripmate.data.repository.FirebaseScrapRepositoryImpl
+import kr.sparta.tripmate.domain.repository.FirebaseScrapRepository
+import kr.sparta.tripmate.domain.usecase.firebasescraprepository.SaveUserData
+import kr.sparta.tripmate.domain.usecase.firebasescraprepository.UpdateUserData
+import kr.sparta.tripmate.ui.viewmodel.scrap.ScrapViewModel
+
+class MyPageFactory : ViewModelProvider.Factory {
+    private val repository : FirebaseScrapRepository by lazy {
+        FirebaseScrapRepositoryImpl(FirebaseDBRemoteDataSource())
+    }
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if(modelClass.isAssignableFrom(MyPageViewModel::class.java)){
+            return MyPageViewModel(
+                UpdateUserData(repository),
+                SaveUserData(repository)
+            )as T
+        }
+        throw IllegalArgumentException("에러")
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/MyPageViewModel.kt
@@ -1,0 +1,22 @@
+package kr.sparta.tripmate.ui.viewmodel.mypage
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import kr.sparta.tripmate.domain.model.login.UserDataEntity
+import kr.sparta.tripmate.domain.usecase.firebasescraprepository.SaveUserData
+import kr.sparta.tripmate.domain.usecase.firebasescraprepository.UpdateUserData
+
+class MyPageViewModel(
+    private val updateUserData: UpdateUserData,
+    private val saveUserData: SaveUserData
+) :
+    ViewModel() {
+    private val _userData: MutableLiveData<UserDataEntity?> = MutableLiveData()
+    val userData get() = _userData
+    fun updateUserData(uid: String) {
+        updateUserData(uid, _userData)
+    }
+    fun saveUserData(model:UserDataEntity){
+        saveUserData(model, _userData)
+    }
+}


### PR DESCRIPTION
## 📌Linked Issues

- #138 

## ✏Change Details

- mypage : User정보를 수정 후 RDB에 저장하고 업데이트 합니다.
- VIewModel&Factory를 추가하고, MVVM 구조로 구현했습니다.
- 나중에 Login화면이나 설정화면에서 추가로 사용할 수 있으므로 RemoteDataSource에 재사용 가능할 수 있도록 user정보 업데이트 및 저장하는 로직을 구현했습니다.
- 
## 💬Comment

- RemoteDataSource에 user를 update하는 부분과 save하는 부분을 나눈 이유는 나중에 LoginActivity나 설정화면 등 다른 페이지에서 사용할것이기 때문입니다.
- 추가로 프로필 사진이나 다른 유저 정보가 변경되더라도 재사용이 가능하게 구현했습니다.

## 📑References


## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
