### PR TITLE
Home& mypage : 조회수 증가

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -78,7 +78,7 @@ class HomeFragment : Fragment() {
                 val intent = CommunityDetailActivity.newIntentForEntity(homeContext, model)
                 startActivity(intent)
                 // 조회수 업데이트
-                homeBoardViewModel.viewHomeBoardData(model, position)
+                homeBoardViewModel.updateBoardView(model)
             }
         )
         binding.homeRecyclerView2.apply {

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/BookmarkFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/BookmarkFragment.kt
@@ -43,10 +43,10 @@ class BookmarkFragment : Fragment() {
                     model.isLike = true
                     bookmarkResults.launch(ScrapDetail.newIntentForScrap(bookmarkContext, model))
                 } else if (model is CommunityModelEntity) {
-                    bookmarkResults.launch(
-                        CommunityDetailActivity.newIntentForEntity
-                            (bookmarkContext, model)
-                    )
+                    viewModel.saveBoardFirebase(model.copy())
+                    val intent = CommunityDetailActivity.newIntentForEntity(bookmarkContext, model)
+                    intent.putExtra("Data", model)
+                    startActivity(intent)
                 }
 //                bookmarkResults.launch(ScrapDetail.newIntentForScrap(bookmarkContext, model))
 //                viewModel.updateBoardDataView(model.toCommunityEntity(), position)
@@ -99,6 +99,7 @@ class BookmarkFragment : Fragment() {
             mypageBoard.observe(viewLifecycleOwner) {
                 Log.d("TripMates", "board: ${it}")
                 mergeScrapAndBoardData()
+                bookmarkAdapter.notifyDataSetChanged()
             }
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardFactory.kt
@@ -6,6 +6,7 @@ import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
 import kr.sparta.tripmate.data.repository.FirebaseBoardRepositoryImpl
 import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetFirebaseBoardDataFromBoardRepo
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.SaveBoardFirebase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateCommuIsViewFromBoardRepo
 
 class HomeBoardFactory : ViewModelProvider.Factory {
@@ -19,7 +20,7 @@ class HomeBoardFactory : ViewModelProvider.Factory {
         if (modelClass.isAssignableFrom(HomeBoardViewModel::class.java)) {
             return HomeBoardViewModel(
                 GetFirebaseBoardDataFromBoardRepo(repository),
-                UpdateCommuIsViewFromBoardRepo(repository)
+                SaveBoardFirebase(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/board/HomeBoardViewModel.kt
@@ -5,10 +5,11 @@ import androidx.lifecycle.ViewModel
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.model.firebase.toCommunity
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetFirebaseBoardDataFromBoardRepo
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.SaveBoardFirebase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateCommuIsViewFromBoardRepo
 
-class HomeBoardViewModel(private val getFirebaseBoardDataFromBoardRepo: GetFirebaseBoardDataFromBoardRepo, private val
-updateCommuIsViewFromBoardRepo: UpdateCommuIsViewFromBoardRepo
+class HomeBoardViewModel(private val getFirebaseBoardDataFromBoardRepo: GetFirebaseBoardDataFromBoardRepo,
+private val saveBoardFirebase: SaveBoardFirebase
 ) :
     ViewModel
     () {
@@ -18,7 +19,11 @@ updateCommuIsViewFromBoardRepo: UpdateCommuIsViewFromBoardRepo
     fun getHomeBoardData(uid: String) {
         getFirebaseBoardDataFromBoardRepo.invoke(_homeBoard)
     }
-    fun viewHomeBoardData(model:CommunityModelEntity,position:Int){
-        updateCommuIsViewFromBoardRepo.invoke(model.toCommunity(), position,_homeBoard)
+    fun updateBoardView(model:CommunityModelEntity){
+        val currentView = model.views?.toIntOrNull() ?:0
+        val newViews = currentView + 1
+        model.views = newViews.toString()
+        saveBoardFirebase.invoke(model, _homeBoard)
+        getHomeBoardData(model.id)
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BookmarkPageFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BookmarkPageFactory.kt
@@ -3,8 +3,11 @@ package kr.sparta.tripmate.ui.viewmodel.mypage
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import kr.sparta.tripmate.data.datasource.remote.FirebaseDBRemoteDataSource
+import kr.sparta.tripmate.data.repository.FirebaseBoardRepositoryImpl
 import kr.sparta.tripmate.data.repository.FirebaseScrapRepositoryImpl
+import kr.sparta.tripmate.domain.repository.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.repository.FirebaseScrapRepository
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.SaveBoardFirebase
 import kr.sparta.tripmate.domain.usecase.firebasescraprepository.GetFirebaseBoardDataFromScrapRepo
 import kr.sparta.tripmate.domain.usecase.firebasescraprepository.GetFirebaseBoardKeyDataFromScrapRepo
 import kr.sparta.tripmate.domain.usecase.firebasescraprepository.GetFirebaseScrapData
@@ -14,6 +17,9 @@ class BookmarkPageFactory : ViewModelProvider.Factory {
     private val repository: FirebaseScrapRepository by lazy {
         FirebaseScrapRepositoryImpl(FirebaseDBRemoteDataSource())
     }
+    private val boardRepository : FirebaseBoardRepository by lazy {
+        FirebaseBoardRepositoryImpl(FirebaseDBRemoteDataSource())
+    }
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(BookmarkPageViewModel::class.java)) {
@@ -21,7 +27,8 @@ class BookmarkPageFactory : ViewModelProvider.Factory {
                 GetFirebaseScrapData(repository),
                 GetFirebaseBoardDataFromScrapRepo(repository),
                 UpdateCommuIsViewFromScrapRepo(repository),
-                GetFirebaseBoardKeyDataFromScrapRepo(repository)
+                GetFirebaseBoardKeyDataFromScrapRepo(repository),
+                SaveBoardFirebase(boardRepository)
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BookmarkPageViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/BookmarkPageViewModel.kt
@@ -1,6 +1,7 @@
 package kr.sparta.tripmate.ui.viewmodel.mypage
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,6 +10,8 @@ import kr.sparta.tripmate.domain.model.firebase.BoardKeyModelEntity
 import kr.sparta.tripmate.domain.model.firebase.CommunityModelEntity
 import kr.sparta.tripmate.domain.model.firebase.ScrapEntity
 import kr.sparta.tripmate.domain.model.firebase.toCommunity
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetFirebaseBoardDataFromBoardRepo
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.SaveBoardFirebase
 import kr.sparta.tripmate.domain.usecase.firebasescraprepository.GetFirebaseBoardDataFromScrapRepo
 import kr.sparta.tripmate.domain.usecase.firebasescraprepository.GetFirebaseBoardKeyDataFromScrapRepo
 import kr.sparta.tripmate.domain.usecase.firebasescraprepository.GetFirebaseScrapData
@@ -20,7 +23,8 @@ class BookmarkPageViewModel(
     private val getFirebaseScrapData: GetFirebaseScrapData,
     private val getFirebaseBoardDataFromScrapRepo: GetFirebaseBoardDataFromScrapRepo,
     private val updateCommuIsViewFromScrapRepo: UpdateCommuIsViewFromScrapRepo,
-    private val getFirebaseBoardKeyDataFromScrapRepo: GetFirebaseBoardKeyDataFromScrapRepo
+    private val getFirebaseBoardKeyDataFromScrapRepo: GetFirebaseBoardKeyDataFromScrapRepo,
+    private val saveBoardFirebase: SaveBoardFirebase
 ) : ViewModel() {
 
     private val _mypageScraps: MutableLiveData<List<ScrapEntity?>> = MutableLiveData()
@@ -42,10 +46,8 @@ class BookmarkPageViewModel(
 
     }
 
-    fun updateBoardData(uid: String) = viewModelScope.launch {
-        kotlin.runCatching {
-            getFirebaseBoardDataFromScrapRepo.invoke(uid, _mypageBoard)
-        }
+    fun updateBoardData(uid: String) {
+        getFirebaseBoardDataFromScrapRepo.invoke(uid, _mypageBoard)
     }
 
     fun updateBoardDataView(model: CommunityModelEntity, position: Int) {
@@ -62,7 +64,7 @@ class BookmarkPageViewModel(
         val boardKey = _boardKey.value ?: emptyList()
         boardKey.forEach { boardKeyItem ->
             val selectItem = boardData.find { it?.key == boardKeyItem?.key }
-            if(selectItem != null){
+            if (selectItem != null) {
                 selectItem.boardIsLike = boardKeyItem!!.myBoardIsLike
             }
         }
@@ -70,5 +72,14 @@ class BookmarkPageViewModel(
         val bookMarkBoardData = boardData.filter { it?.boardIsLike == true }
 
         _totalMyPage.value = scraps + bookMarkBoardData
+    }
+
+    fun saveBoardFirebase(model: CommunityModelEntity) {
+        val currentView = model.views?.toIntOrNull() ?: 0
+        val newViews = currentView + 1
+        Log.d("ssss", "조회수오르니? ${newViews}")
+        model.views = newViews.toString()
+        saveBoardFirebase(model, _mypageBoard)
+        updateBoardData(model.id)
     }
 }


### PR DESCRIPTION
## 📌Linked Issues

- #150 

## ✏Change Details

- Home의 인기글 목록과 mypage의 스크랩에서 카테고리 아이템 클릭시 조회수가 실시간 증가하고 갱신됩니다.

## 💬Comment

- 커뮤니티는 좋아요 기능 수정 후에 조회수 넣겠습니다. 기존의 함수들 재활용하면 되는거라 금방합니다.

## 📑References


## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
