### PR TITLE
userpage&home&mypage&setting&community : UI, 버그, 기능 / github action 빌드 에러 후 수정 완료하고 재 빌드 완료했습니다.

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityDetailActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityDetailActivity.kt
@@ -262,10 +262,9 @@ class CommunityDetailActivity : AppCompatActivity() {
      * */
     private fun toggleBoardScrap(isBoardScrap: Boolean) = with(binding) {
         if (isBoardScrap) {
-            communityDetailLikeBtn.setImageResource(R.drawable.ic_star_filled)
+            communityDetailLikeBtn.setImageResource(R.drawable.star_filled)
         } else {
-            communityDetailLikeBtn.setImageResource(R.drawable.ic_star)
+            communityDetailLikeBtn.setImageResource(R.drawable.star)
         }
     }
-
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeBudgetListAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeBudgetListAdapter.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import kr.sparta.tripmate.data.model.budget.Budget
-import kr.sparta.tripmate.databinding.ItemBudgetBinding
+import kr.sparta.tripmate.databinding.HomebudgetitemBinding
 import kr.sparta.tripmate.util.method.toMoneyFormat
 
 class HomeBudgetListAdapter(private val onItemClicked: (Budget) -> Unit) :
@@ -22,14 +22,13 @@ class HomeBudgetListAdapter(private val onItemClicked: (Budget) -> Unit) :
 
     }) {
 
-    inner class ViewHolder(private val binding: ItemBudgetBinding) :
+    inner class ViewHolder(private val binding: HomebudgetitemBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item:Budget) = with(binding) {
-//            root.setOnClickListener { budgetListEventListener.itemClicked(currentList[absoluteAdapterPosition]) }
-            budgetItemStatusBeforeTextview.text ="${item.money.toMoneyFormat()}원"
-            budgetItemStatusAfterTextview.text = "${item.resultMoeny.toMoneyFormat()}원"
-            budgetItemDurationTextview.text = "${item.startDate} ~ ${item.endDate}"
-            budgetItemTitleTextview.text = item.name
+            homeBudgetItemStatusBeforeTextview.text ="${item.money.toMoneyFormat()}원"
+            homeBudgetItemStatusAfterTextview.text = "${item.resultMoeny.toMoneyFormat()}원"
+            homeBudgetItemDurationTextview.text = "${item.startDate} ~ ${item.endDate}"
+            homeBudgetItemTitleTextview.text = item.name
 
             itemView.setOnClickListener{
                 onItemClicked(item)
@@ -39,7 +38,7 @@ class HomeBudgetListAdapter(private val onItemClicked: (Budget) -> Unit) :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return ViewHolder(ItemBudgetBinding.inflate(inflater, parent, false))
+        return ViewHolder(HomebudgetitemBinding.inflate(inflater, parent, false))
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeBudgetListAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeBudgetListAdapter.kt
@@ -1,0 +1,49 @@
+package kr.sparta.tripmate.ui.home
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import kr.sparta.tripmate.data.model.budget.Budget
+import kr.sparta.tripmate.databinding.ItemBudgetBinding
+import kr.sparta.tripmate.util.method.toMoneyFormat
+
+class HomeBudgetListAdapter(private val onItemClicked: (Budget) -> Unit) :
+    ListAdapter<Budget, HomeBudgetListAdapter.ViewHolder>(object : DiffUtil.ItemCallback<Budget>() {
+        override fun areItemsTheSame(oldItem: Budget, newItem: Budget): Boolean {
+            return oldItem.num == newItem.num
+        }
+
+        override fun areContentsTheSame(oldItem: Budget, newItem: Budget): Boolean {
+            return oldItem == newItem && oldItem.resultMoeny == newItem.resultMoeny
+        }
+
+    }) {
+
+    inner class ViewHolder(private val binding: ItemBudgetBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item:Budget) = with(binding) {
+//            root.setOnClickListener { budgetListEventListener.itemClicked(currentList[absoluteAdapterPosition]) }
+            budgetItemStatusBeforeTextview.text ="${item.money.toMoneyFormat()}원"
+            budgetItemStatusAfterTextview.text = "${item.resultMoeny.toMoneyFormat()}원"
+            budgetItemDurationTextview.text = "${item.startDate} ~ ${item.endDate}"
+            budgetItemTitleTextview.text = item.name
+
+            itemView.setOnClickListener{
+                onItemClicked(item)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return ViewHolder(ItemBudgetBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -12,12 +12,16 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import coil.load
 import kr.sparta.tripmate.R
+import kr.sparta.tripmate.data.repository.budget.BudgetRepositoryImpl
 import kr.sparta.tripmate.databinding.FragmentHomeBinding
+import kr.sparta.tripmate.ui.budget.detail.main.BudgetDetailActivity
 import kr.sparta.tripmate.ui.community.CommunityDetailActivity
 import kr.sparta.tripmate.ui.main.MainActivity
 import kr.sparta.tripmate.ui.scrap.detail.ScrapDetailActivity
 import kr.sparta.tripmate.ui.viewmodel.home.board.HomeBoardFactory
 import kr.sparta.tripmate.ui.viewmodel.home.board.HomeBoardViewModel
+import kr.sparta.tripmate.ui.viewmodel.home.budget.HomeBudgetFactory
+import kr.sparta.tripmate.ui.viewmodel.home.budget.HomeBudgetViewModel
 import kr.sparta.tripmate.ui.viewmodel.home.scrap.HomeBlogScrapFactory
 import kr.sparta.tripmate.ui.viewmodel.home.scrap.HomeBlogScrapViewModel
 import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
@@ -39,6 +43,16 @@ class HomeFragment : Fragment() {
 
     private val homeBoardViewModel: HomeBoardViewModel by viewModels {
         HomeBoardFactory()
+    }
+    private val homeBudgetViewModel: HomeBudgetViewModel by viewModels {
+        HomeBudgetFactory(BudgetRepositoryImpl(homeContext))
+    }
+    private val homeBudgetListAdapter: HomeBudgetListAdapter by lazy {
+        HomeBudgetListAdapter(
+            onItemClicked = {
+                startActivity(BudgetDetailActivity.newIntentForBudget(homeContext,it))
+            }
+        )
     }
 
     private val homeScrapListAdapter: HomeScrapListAdapter by lazy {
@@ -118,6 +132,11 @@ class HomeFragment : Fragment() {
             adapter = homeBoardListAdapter
             setHasFixedSize(true)
         }
+        homeBudgetRecyclerview.apply {
+            layoutManager = GridLayoutManager(homeContext, 1, GridLayoutManager.HORIZONTAL, false)
+            adapter = homeBudgetListAdapter
+            setHasFixedSize(true)
+        }
 
         val uid = SharedPreferences.getUid(homeContext)
         // 블로그 불러오기
@@ -169,6 +188,14 @@ class HomeFragment : Fragment() {
                     it.sortedByDescending { it1 -> it1?.likes }
                 }.orEmpty()
                 homeBoardListAdapter.submitList(sortedList)
+            }
+        }
+        with(homeBudgetViewModel) {
+            budgetLiveDataWhenBudgetChanged.observe(viewLifecycleOwner) {
+                homeBudgetListAdapter.submitList(it)
+            }
+            budgetLiveDataWhenProcedureChanged.observe(viewLifecycleOwner) {
+                homeBudgetListAdapter.submitList(it)
             }
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardFragment.kt
@@ -73,7 +73,6 @@ class UserProfileBoardFragment : Fragment() {
         with(userProfileBoardViewModel) {
             userPage.observe(viewLifecycleOwner) {
                 boardAdapter.submitList(it)
-                boardAdapter.notifyDataSetChanged()
             }
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardListAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardListAdapter.kt
@@ -29,7 +29,7 @@ class UserProfileBoardListAdapter(
                 oldItem: CommunityEntity,
                 newItem: CommunityEntity
             ): Boolean {
-                return oldItem.key == newItem.key
+                return oldItem == newItem
             }
 
         }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/budget/HomeBudgetFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/budget/HomeBudgetFactory.kt
@@ -1,0 +1,17 @@
+package kr.sparta.tripmate.ui.viewmodel.home.budget
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.sparta.tripmate.domain.repository.budget.BudgetRepository
+import kr.sparta.tripmate.ui.viewmodel.budget.BudgetViewModel
+
+class HomeBudgetFactory(
+    private val repository: BudgetRepository,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HomeBudgetViewModel::class.java)) {
+            return HomeBudgetViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel Class")
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/budget/HomeBudgetViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/home/budget/HomeBudgetViewModel.kt
@@ -1,0 +1,14 @@
+package kr.sparta.tripmate.ui.viewmodel.home.budget
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
+import kr.sparta.tripmate.data.model.budget.Budget
+import kr.sparta.tripmate.domain.repository.budget.BudgetRepository
+
+class HomeBudgetViewModel(repository: BudgetRepository) : ViewModel() {
+    val budgetLiveDataWhenBudgetChanged: LiveData<List<Budget>> =
+        repository.getAllBudgetsToFlowWhenBugetsChanged().asLiveData()
+    val budgetLiveDataWhenProcedureChanged: LiveData<List<Budget>> =
+        repository.getAllBugetsToFlowWhenProceduresChanged().asLiveData()
+}

--- a/app/src/main/res/drawable/arrow_left.xml
+++ b/app/src/main/res/drawable/arrow_left.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/black"
+        android:fillColor="@color/white"
         android:pathData="M4,12L3.293,11.293L2.586,12L3.293,12.707L4,12ZM19,13C19.552,13 20,12.552 20,12C20,11.448 19.552,11 19,11V13ZM9.293,5.293L3.293,11.293L4.707,12.707L10.707,6.707L9.293,5.293ZM3.293,12.707L9.293,18.707L10.707,17.293L4.707,11.293L3.293,12.707ZM4,13H19V11H4V13Z" />
 </vector>

--- a/app/src/main/res/layout/activity_community_detail.xml
+++ b/app/src/main/res/layout/activity_community_detail.xml
@@ -8,7 +8,8 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:background="@color/primary">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/community_detail_toolbar"
@@ -25,7 +26,7 @@
                 android:layout_height="30dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_star" />
+                android:src="@drawable/star" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/community_detail_remove"
@@ -33,6 +34,7 @@
                 android:layout_height="30dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="10dp"
+                android:backgroundTint="@color/white"
                 android:background="@drawable/ic_delete" />
 
             <androidx.appcompat.widget.AppCompatButton
@@ -41,7 +43,8 @@
                 android:layout_height="30dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="10dp"
-                android:background="@drawable/ic_edit"/>
+                android:backgroundTint="@color/white"
+                android:background="@drawable/ic_edit" />
         </androidx.appcompat.widget.Toolbar>
 
         <TextView
@@ -51,133 +54,144 @@
             android:layout_marginHorizontal="20dp"
             android:ellipsize="end"
             android:maxLines="2"
-            tools:text="@string/community_detail_title"
             android:textSize="24sp"
             android:textStyle="bold"
+            android:textColor="@color/white"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/community_detail_toolbar"
-             />
+            tools:text="@string/community_detail_title" />
 
-        <de.hdodenhof.circleimageview.CircleImageView
-            android:id="@+id/community_userprofile"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="20dp"
-            android:src="@drawable/ic_user_profile"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/community_tv_detail_title"
-             />
-
-        <TextView
-            android:id="@+id/community_tv_detail_username"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="5dp"
-            android:text="@string/community_detail_username"
-            android:textColor="@color/sub_text_color"
-            android:textSize="16sp"
-            app:layout_constraintStart_toEndOf="@+id/community_userprofile"
-            app:layout_constraintTop_toTopOf="@+id/community_userprofile"
-            app:layout_constraintBottom_toBottomOf="@+id/community_userprofile"
-             />
-
-        <LinearLayout
-            android:id="@+id/community_image_container"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/community_detail_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="20dp"
-            android:paddingVertical="10dp"
-            android:orientation="vertical"
+            android:layout_marginTop="20dp"
+            android:background="@color/white"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/community_tv_detail_username">
+            app:layout_constraintTop_toBottomOf="@+id/community_tv_detail_title">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/community_image_card_view"
+            <de.hdodenhof.circleimageview.CircleImageView
+                android:id="@+id/community_userprofile"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginHorizontal="20dp"
+                android:layout_marginTop="10dp"
+                android:src="@drawable/ic_user_profile"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/community_detail_layout" />
+
+            <TextView
+                android:id="@+id/community_tv_detail_username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:text="@string/community_detail_username"
+                android:textColor="@color/sub_text_color"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@+id/community_userprofile"
+                app:layout_constraintStart_toEndOf="@+id/community_userprofile"
+                app:layout_constraintTop_toTopOf="@+id/community_userprofile" />
+
+            <LinearLayout
+                android:id="@+id/community_image_container"
                 android:layout_width="match_parent"
-                android:layout_height="300dp"
-                android:layout_margin="15dp"
-                android:visibility="visible"
-                app:cardCornerRadius="30dp"
-                app:cardElevation="5dp">
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="20dp"
+                android:orientation="vertical"
+                android:paddingVertical="10dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/community_tv_detail_username">
 
-
-                <ImageView
-                    android:id="@+id/community_image_iv"
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/community_image_card_view"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:scaleType="centerCrop"
-                    tools:src="@drawable/emptycommu" />
-
-                <ProgressBar
-                    android:id="@+id/community_detail_image_progressbar"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    android:layout_gravity="center"
-                    android:indeterminateTint="@color/primary" />
-
-            </androidx.cardview.widget.CardView>
-
-        </LinearLayout>
+                    android:layout_height="300dp"
+                    android:layout_margin="15dp"
+                    android:visibility="visible"
+                    app:cardCornerRadius="30dp"
+                    app:cardElevation="5dp">
 
 
-        <ImageView
-            android:id="@+id/community_iv_like"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginTop="10dp"
-            app:layout_constraintStart_toStartOf="@+id/community_tv_detail_title"
-            app:layout_constraintTop_toBottomOf="@+id/community_image_container"
-            app:srcCompat="@drawable/paintedheart" />
+                    <ImageView
+                        android:id="@+id/community_image_iv"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:scaleType="centerCrop"
+                        tools:src="@drawable/emptycommu" />
 
-        <TextView
-            android:id="@+id/community_detail_likecount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginStart="3dp"
-            android:textColor="@color/sub_text_color"
-            app:layout_constraintBottom_toBottomOf="@+id/community_iv_like"
-            app:layout_constraintStart_toEndOf="@+id/community_iv_like"
-            app:layout_constraintTop_toTopOf="@+id/community_iv_like"
-            tools:text="@string/community_detail_likecount" />
+                    <ProgressBar
+                        android:id="@+id/community_detail_image_progressbar"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:indeterminateTint="@color/primary"
+                        android:visibility="gone" />
 
-        <ImageView
-            android:id="@+id/community_iv_view"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginStart="20dp"
-            app:layout_constraintBottom_toBottomOf="@+id/community_iv_like"
-            app:layout_constraintStart_toEndOf="@+id/community_detail_likecount"
-            app:layout_constraintTop_toTopOf="@+id/community_iv_like"
-            app:srcCompat="@drawable/witness" />
+                </androidx.cardview.widget.CardView>
 
-        <TextView
-            android:id="@+id/community_tv_detail_viewcount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="3dp"
-            android:textColor="@color/sub_text_color"
-            app:layout_constraintBottom_toBottomOf="@+id/community_iv_like"
-            app:layout_constraintStart_toEndOf="@+id/community_iv_view"
-            app:layout_constraintTop_toTopOf="@+id/community_iv_like"
-            tools:text="@string/community_detail_viewcount" />
+            </LinearLayout>
 
-        <TextView
-            android:id="@+id/community_tv_detail_description"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_marginVertical="30dp"
-            android:lineSpacingExtra="8dp"
-            android:textColor="@color/sub_text_color"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/community_tv_detail_title"
-            app:layout_constraintStart_toStartOf="@+id/community_tv_detail_title"
-            app:layout_constraintTop_toBottomOf="@+id/community_tv_detail_viewcount"
-            tools:text="@string/community_detail_body" />
+
+            <ImageView
+                android:id="@+id/community_iv_like"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="10dp"
+                app:layout_constraintStart_toStartOf="@+id/community_detail_layout"
+                app:layout_constraintTop_toBottomOf="@+id/community_image_container"
+                app:srcCompat="@drawable/paintedheart" />
+
+            <TextView
+                android:id="@+id/community_detail_likecount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="3dp"
+                android:textColor="@color/sub_text_color"
+                app:layout_constraintBottom_toBottomOf="@+id/community_iv_like"
+                app:layout_constraintStart_toEndOf="@+id/community_iv_like"
+                app:layout_constraintTop_toTopOf="@+id/community_iv_like"
+                tools:text="@string/community_detail_likecount" />
+
+            <ImageView
+                android:id="@+id/community_iv_view"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="20dp"
+                app:layout_constraintBottom_toBottomOf="@+id/community_iv_like"
+                app:layout_constraintStart_toEndOf="@+id/community_detail_likecount"
+                app:layout_constraintTop_toTopOf="@+id/community_iv_like"
+                app:srcCompat="@drawable/witness" />
+
+            <TextView
+                android:id="@+id/community_tv_detail_viewcount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="3dp"
+                android:textColor="@color/sub_text_color"
+                app:layout_constraintBottom_toBottomOf="@+id/community_iv_like"
+                app:layout_constraintStart_toEndOf="@+id/community_iv_view"
+                app:layout_constraintTop_toTopOf="@+id/community_iv_like"
+                tools:text="@string/community_detail_viewcount" />
+
+            <TextView
+                android:id="@+id/community_tv_detail_description"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_marginVertical="30dp"
+                android:layout_marginStart="20dp"
+                android:lineSpacingExtra="8dp"
+                android:textColor="@color/sub_text_color"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@+id/community_detail_layout"
+                app:layout_constraintStart_toStartOf="@+id/community_detail_layout"
+                app:layout_constraintTop_toBottomOf="@+id/community_tv_detail_viewcount"
+                tools:text="@string/community_detail_body" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_community_write.xml
+++ b/app/src/main/res/layout/activity_community_write.xml
@@ -40,6 +40,7 @@
         android:maxLines="2"
         android:textSize="24sp"
         android:textStyle="bold"
+        android:singleLine="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_community_write.xml
+++ b/app/src/main/res/layout/activity_community_write.xml
@@ -13,7 +13,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="@drawable/arrow_left">
+        app:navigationIcon="@drawable/arrow_left"
+        android:background="@color/primary">
 
         <TextView
             android:id="@+id/community_write_post"
@@ -22,18 +23,19 @@
             android:layout_gravity="right|center_vertical"
             android:layout_marginEnd="15dp"
             android:text="@string/community_write_post_text"
-            android:textColor="@color/primary"
+            android:backgroundTint="@color/white"
+            android:textColor="@color/white"
             android:textSize="18sp"
             android:textStyle="bold" />
 
     </androidx.appcompat.widget.Toolbar>
-
 
     <EditText
         android:id="@+id/community_write_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="15dp"
+        android:layout_marginTop="10dp"
         android:background="@null"
         android:ellipsize="end"
         android:hint="@string/pleaseentertitle"
@@ -42,7 +44,6 @@
         android:textStyle="bold"
         android:singleLine="true"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/community_write_toolbar" />
 

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -27,8 +27,8 @@
 
     <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/setting_Profile_Image"
-        android:layout_width="200dp"
-        android:layout_height="200dp"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
         android:layout_marginVertical="15dp"
         app:layout_constraintBottom_toTopOf="@id/setting_loginType"
         app:layout_constraintStart_toStartOf="parent"
@@ -71,7 +71,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/setting_button_logout"
         android:text="@string/setting_logout_button_text"
-        android:textSize="18sp"
+        android:textSize="15sp"
         android:textStyle="bold"
         android:fontFamily="@font/inter"
         android:layout_marginVertical="20dp"
@@ -87,7 +87,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/setting_button_withdrawal"
         android:text="@string/setting_withdrawal_button_text"
-        android:textSize="18sp"
+        android:textSize="15sp"
         android:textStyle="bold"
         android:fontFamily="@font/inter"
         android:layout_marginVertical="20dp"

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -16,7 +16,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:titleTextColor="@color/white">
+        app:titleTextColor="@color/white"
+        app:navigationIcon="@drawable/arrow_left">
 
         <TextView
             android:id="@+id/user_info_tv"
@@ -76,11 +77,13 @@
 
             <TextView
                 android:id="@+id/user_profile_content_textview"
-                android:layout_width="180dp"
-                android:layout_height="24.4dp"
-                android:layout_marginTop="10dp"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
                 android:layout_marginStart="11dp"
+                android:ellipsize="end"
+                android:maxLines="2"
                 android:scrollbars="vertical"
+                android:textColor="@color/sub_text_color"
                 android:text="안녕하세요!"
                 app:layout_constraintStart_toEndOf="@+id/user_profile_layout"
                 app:layout_constraintTop_toBottomOf="@+id/user_profile_nick_textview" />
@@ -129,10 +132,9 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/Gray300"
-        android:layout_marginHorizontal="25dp"
         android:layout_marginTop="88dp"
+        android:layout_marginHorizontal="25dp"
         app:layout_constraintTop_toTopOf="@+id/user_tab_linear_layout"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_user_profile.xml
+++ b/app/src/main/res/layout/activity_user_profile.xml
@@ -32,7 +32,7 @@
         android:layout_width="match_parent"
         android:layout_height="101.03704dp"
         android:layout_marginStart="26dp"
-        android:layout_marginTop="57dp"
+        android:layout_marginTop="77dp"
         android:layout_marginEnd="26dp"
         android:padding="5dp"
         android:visibility="visible"
@@ -105,7 +105,7 @@
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="20dp"
+            android:layout_height="40dp"
             android:background="@color/white">
 
         </FrameLayout>
@@ -124,5 +124,15 @@
             android:layout_height="match_parent"
             android:background="@color/white" />
     </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/Gray300"
+        android:layout_marginHorizontal="25dp"
+        android:layout_marginTop="88dp"
+        app:layout_constraintTop_toTopOf="@+id/user_tab_linear_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -227,7 +227,7 @@
                         android:src="@drawable/arrow_right"
                         android:layout_marginEnd="15dp"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintBottom_toTopOf="@+id/home_recyclerView3"
+                        app:layout_constraintBottom_toTopOf="@+id/home_budget_recyclerview"
                         app:layout_constraintTop_toTopOf="@+id/budget_const" />
 
                     <View
@@ -243,7 +243,7 @@
                         app:layout_constraintTop_toBottomOf="@+id/home_title3" />
 
                     <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/home_recyclerView3"
+                        android:id="@+id/home_budget_recyclerview"
                         android:layout_width="match_parent"
                         android:layout_height="180dp"
                         android:layout_marginStart="15dp"

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -219,7 +219,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/Gray300"
-        android:layout_marginHorizontal="30dp"
+        android:layout_marginHorizontal="25dp"
         android:layout_marginTop="88dp"
         app:layout_constraintTop_toTopOf="@+id/linearLayout2"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -119,11 +119,13 @@
 
             <TextView
                 android:id="@+id/mypage_profile_content_textview"
-                android:layout_width="180dp"
-                android:layout_height="24.4dp"
-                android:layout_marginTop="12dp"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
                 android:layout_marginStart="11dp"
+                android:ellipsize="end"
+                android:maxLines="2"
                 android:scrollbars="vertical"
+                android:textColor="@color/sub_text_color"
                 android:text="안녕하세요!"
                 app:layout_constraintStart_toEndOf="@+id/mypage_profile_layout"
                 app:layout_constraintTop_toBottomOf="@+id/mypage_profile_nick_textview" />
@@ -207,7 +209,14 @@
             android:backgroundTint="@color/white"
             app:tabIndicatorColor="@color/black"
             app:tabTextColor="@color/black" />
-
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/Gray300"
+            android:layout_marginHorizontal="25dp"
+            app:layout_constraintTop_toBottomOf="@+id/mypage_tablayout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/mypage_viewpager"
             android:layout_width="match_parent"
@@ -215,13 +224,5 @@
             android:background="@color/white" />
 
     </LinearLayout>
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/Gray300"
-        android:layout_marginHorizontal="25dp"
-        android:layout_marginTop="88dp"
-        app:layout_constraintTop_toTopOf="@+id/linearLayout2"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -61,7 +61,7 @@
         android:layout_width="match_parent"
         android:layout_height="101.03704dp"
         android:layout_marginStart="26dp"
-        android:layout_marginTop="57dp"
+        android:layout_marginTop="77dp"
         android:layout_marginEnd="26dp"
         android:padding="5dp"
         android:visibility="visible"
@@ -147,7 +147,7 @@
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="20dp"
+            android:layout_height="40dp"
             android:background="@color/white">
 
         </FrameLayout>
@@ -215,5 +215,13 @@
             android:background="@color/white" />
 
     </LinearLayout>
-
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/Gray300"
+        android:layout_marginHorizontal="30dp"
+        android:layout_marginTop="88dp"
+        app:layout_constraintTop_toTopOf="@+id/linearLayout2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_scrap.xml
+++ b/app/src/main/res/layout/fragment_scrap.xml
@@ -119,6 +119,7 @@
                 android:text="@string/click_on_the_image_to_search"
                 android:textSize="13sp"
                 android:textColor="@color/sub_text_color"
+                app:layout_constraintBottom_toTopOf="@+id/scrap_imagesearch_view"
                 app:layout_constraintEnd_toEndOf="@+id/scrap_imageframe"
                 app:layout_constraintStart_toStartOf="@+id/scrap_imageframe"/>
 

--- a/app/src/main/res/layout/homebudgetitem.xml
+++ b/app/src/main/res/layout/homebudgetitem.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/home_budget_layout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="15dp"
+    android:paddingVertical="10dp"
+   android:layout_margin="10dp"
+    android:background="@drawable/background_budget_view_type5">
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/home_budget_item_title_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="15dp"
+            android:layout_marginBottom="10dp"
+            android:background="@drawable/background_budget_view_type2"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="7dp"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            app:layout_constraintStart_toStartOf="@+id/view"
+            app:layout_constraintTop_toTopOf="@+id/view"
+            tools:text="스페인  여행 가계부" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="@+id/home_budget_layout"
+        app:layout_constraintStart_toStartOf="@+id/home_budget_layout"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="15dp"
+                android:text="원금"
+                android:textColor="#555555"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@+id/view2"
+                app:layout_constraintTop_toBottomOf="@+id/linearLayout" />
+
+            <TextView
+                android:id="@+id/home_budget_item_status_before_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="33dp"
+                android:fontFamily="@font/inter"
+                android:maxLines="1"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                tools:text="5,000,000,000 원" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="15dp"
+                android:text="남은 예산"
+                android:textColor="#555555"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@+id/guideline2"
+                app:layout_constraintTop_toBottomOf="@+id/linearLayout" />
+
+            <TextView
+                android:id="@+id/home_budget_item_status_after_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/inter"
+                android:maxLines="1"
+                android:textColor="@color/black"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                tools:text="5,000,000,000 원" />
+
+        </LinearLayout>
+
+        <View
+            android:id="@+id/view2"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_margin="15dp"
+            android:background="@color/Gray300" />
+
+        <TextView
+            android:id="@+id/home_budget_item_duration_textview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:fontFamily="@font/inter"
+            android:paddingBottom="10dp"
+            android:textColor="#555555"
+            android:textSize="12sp"
+            tools:text="2023.12.09 ~ 2023.12.21" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/home_budget_guideline2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
+
+    </LinearLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## **페이지명 : 수정내용**

## #185 #186 

- 해당이슈 링크 없을경우 생략가능

## ✏Change Details

### 버그 수정
- userpage : 조회수와 좋아요의 갱신이 느리던 부분을 수정했습니다.
- mypage : 자기소개 편집할때 구분선이 겹치는 부분을 수정했습니다.
- github/action : 빌드 에러를 수정했습니다.

### 기능 구현
- Home : 가계부 관련 viewModel& Factory를 추가했습니다.
- Home : 가계부 데이터가 화면에 표시됩니다. 아이템 클릭 시 상세 페이지로 이동됩니다.

### UI 수정
- 툴바의 뒤로가기 색상을 white로 변경했습니다.
- mypage : 텝레이아웃과 리사이클러뷰 사이에 구분선을 표시했습니다.
- mypage : RDB에 저장된 자기소개가 모두 표시되도록 수정했습니다.
- mypage : 바드뷰가 툴바와 너무 붙는 부분을 수정했습니다.
- userprofile : 탭 레이아웃과 리사이클러뷰 사이에 구분선을 표시했습니다.
- userprofile : 툴바에 뒤로가기를 추가했습니다. 
- userprofile : RDB에 저장된 자기소개가 모두 표시되도록 수정했습니다.
- setting : 프로필 사진 & 로그아웃& 회원탈퇴 textSize를 줄였습니다.
- community/detail : 피그마에 맞게 UI를 수정했습니다.
- community/write : title 작성 시 키보드의 엔터를 다음탭으로 이동되도록 수정했습니다.
### 이름 변경
- Home : 가계부 리사이클러뷰의 이름을 변경했습니다.
## 💬Comment

- 해당 PR 살펴볼시 참고하면 좋을 사항들을 기록하기.
- 참고사항이 없을경우 기록하지 않아도 무방.

## 📑References

- 내가 개발을 진행하며 참고했던 사이트링크 혹은 해당 구현사항을 파악하는데 도움이 되는 링크

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
