### PR TITLE
home&setting&community&userprofile :  UI&버그&기능 수정

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/community/FirebaseBoardRemoteDataSource.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/community/FirebaseBoardRemoteDataSource.kt
@@ -44,11 +44,12 @@ class FirebaseBoardRemoteDataSource {
      * 작성자: 서정한
      * 내용: 커뮤니티 게시글 가져오기
      * */
-    private fun getBoard(key: String): Flow<CommunityModel?> {
-        val ref = getReference().child(key)
-
-        return ref.snapshots.mapNotNull {
-            it.getValue<CommunityModel>()
+    fun getBoard(key: String): Flow<CommunityModel?> {
+        val ref = getReference()
+        return ref.snapshots.map { snapshot ->
+            snapshot.children.mapNotNull {
+                it.getValue<CommunityModel>()
+            }.find { it.key == key }
         }
     }
 
@@ -99,7 +100,7 @@ class FirebaseBoardRemoteDataSource {
      * */
     fun removeBoard(key: String) {
         val ref = getReference()
-        ref.get().addOnSuccessListener {snapshot ->
+        ref.get().addOnSuccessListener { snapshot ->
             val boards = snapshot.children.map {
                 it.getValue(CommunityModel::class.java)
             }.toMutableList()

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/community/FirebaseBoardRepositoryImpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/community/FirebaseBoardRepositoryImpl.kt
@@ -62,4 +62,5 @@ class FirebaseBoardRepositoryImpl(
     override fun getKey(): String = remoteSource.getKey()
 
     override fun updateBoard(item: CommunityEntity) = remoteSource.updateBoard(item.toModel())
+    override fun getBoard(key: String) : Flow<CommunityModel?>  = remoteSource.getBoard(key)
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/repository/community/FirebaseBoardRepository.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/repository/community/FirebaseBoardRepository.kt
@@ -46,4 +46,6 @@ interface FirebaseBoardRepository {
     fun getKey(): String
 
     fun updateBoard(item: CommunityEntity)
+
+    fun getBoard(key: String): Flow<CommunityModel?>
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseboardrepository/GetBoardUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseboardrepository/GetBoardUseCase.kt
@@ -1,0 +1,7 @@
+package kr.sparta.tripmate.domain.usecase.firebaseboardrepository
+
+import kr.sparta.tripmate.domain.repository.community.FirebaseBoardRepository
+
+class GetBoardUseCase(private val repository: FirebaseBoardRepository) {
+    operator fun invoke(key: String) = repository.getBoard(key)
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/community/main/CommunityFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/community/main/CommunityFragment.kt
@@ -66,9 +66,7 @@ class CommunityFragment : Fragment() {
 
                 // 게시글 상세페이지 이동
                 val intent = CommunityDetailActivity.newIntentForEntity(
-                    communityContext, model.copy(
-                        views = model.views
-                    )
+                    communityContext, model.key!!
                 )
                 startActivity(intent)
             },

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -71,10 +71,12 @@ class HomeFragment : Fragment() {
     private val homeBoardListAdapter: HomeBoardListAdapter by lazy {
         HomeBoardListAdapter(
             onItemClick = { model ->
-                val intent = CommunityDetailActivity.newIntentForEntity(homeContext, model)
-                startActivity(intent)
-                // 조회수 업데이트
-                homeBoardViewModel.updateBoardView(model)
+                model.key?.let {
+                    val intent = CommunityDetailActivity.newIntentForEntity(homeContext, model.key)
+                    startActivity(intent)
+                    // 조회수 업데이트
+                    homeBoardViewModel.updateBoardView(model)
+                }
             }
         )
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/board/MyPageBoardFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/board/MyPageBoardFragment.kt
@@ -27,12 +27,14 @@ class MyPageBoardFragment : Fragment() {
     private val boardAdapter by lazy {
         MyPageBoardListAdapter(
             onItemClicked = { model ->
-                // 조회수 업데이트
-                viewModel.updateBoardView(model)
+                model.key?.let {
+                    // 조회수 업데이트
+                    viewModel.updateBoardView(model)
 
-                // 게시글로 이동
-                val intent = CommunityDetailActivity.newIntentForEntity(boardContext, model)
-                startActivity(intent)
+                    // 게시글로 이동
+                    val intent = CommunityDetailActivity.newIntentForEntity(boardContext, model.key)
+                    startActivity(intent)
+                }
             },
             onLikeClicked = {model ->
                 val uid = SharedPreferences.getUid(boardContext)

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/MyPageScrapFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/MyPageScrapFragment.kt
@@ -50,11 +50,13 @@ class MyPageScrapFragment : Fragment() {
                     )
                     bookmarkResults.launch(intent)
                 } else if (model is CommunityEntity) {
-                    // 조회수 증가
-                    viewModel.updateBoardViews(model.copy())
+                   model.key?.let {
+                       // 조회수 증가
+                       viewModel.updateBoardViews(model.copy())
 
-                    val intent = CommunityDetailActivity.newIntentForEntity(scrapContext, model)
-                    startActivity(intent)
+                       val intent = CommunityDetailActivity.newIntentForEntity(scrapContext, model.key)
+                       startActivity(intent)
+                   }
                 }
 //                bookmarkResults.launch(ScrapDetail.newIntentForScrap(bookmarkContext, model))
 //                viewModel.updateBoardDataView(model.toCommunityEntity(), position)

--- a/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardFragment.kt
@@ -25,7 +25,7 @@ class UserProfileBoardFragment : Fragment() {
         fun newInstance(): UserProfileBoardFragment = UserProfileBoardFragment()
     }
 
-    private lateinit var uid: String
+    private lateinit var userUid: String
     private val userProfileBoardViewModel: UserProfileBoardViewModel by viewModels {
         UserProfileBoardFactory()
     }
@@ -42,6 +42,7 @@ class UserProfileBoardFragment : Fragment() {
             },
             onLikeClicked = { model, position ->
                 model.key?.let {
+                    val uid = SharedPreferences.getUid(boardContext)
                     userProfileBoardViewModel.updateCommuIsLike(uid, it)
                 }
             }
@@ -51,7 +52,7 @@ class UserProfileBoardFragment : Fragment() {
     override fun onAttach(context: Context) {
         super.onAttach(context)
         boardContext = context
-        uid = SharedPreferences.getUidFromUser(boardContext)
+        userUid = SharedPreferences.getUidFromUser(boardContext)
     }
 
     override fun onCreateView(
@@ -91,7 +92,7 @@ class UserProfileBoardFragment : Fragment() {
     }
 
     fun callDataSource() {
-        userProfileBoardViewModel.getFirebaseBoardData(uid)
+        userProfileBoardViewModel.getFirebaseBoardData(userUid)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardFragment.kt
@@ -36,9 +36,11 @@ class UserProfileBoardFragment : Fragment() {
     private val boardAdapter by lazy {
         UserProfileBoardListAdapter(
             onItemClicked = { model, position ->
-                userProfileBoardViewModel.updateView(model)
-                val intent = CommunityDetailActivity.newIntentForEntity(boardContext, model)
-                startActivity(intent)
+                model.key?.let {
+                    userProfileBoardViewModel.updateView(model)
+                    val intent = CommunityDetailActivity.newIntentForEntity(boardContext, model.key)
+                    startActivity(intent)
+                }
             },
             onLikeClicked = { model, position ->
                 model.key?.let {

--- a/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardListAdapter.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/userprofile/board/UserProfileBoardListAdapter.kt
@@ -48,7 +48,7 @@ class UserProfileBoardListAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: CommunityEntity) = with(binding) {
             fun toggleIsLikeIcon() {
-                val uid = SharedPreferences.getUidFromUser(itemView.context)
+                val uid = SharedPreferences.getUid(itemView.context)
                 val isLike = item.likeUsers.find { it == uid } ?: ""
 
                 if (isLike != "") {

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailFactory.kt
@@ -26,7 +26,8 @@ class CommunityDetailFactory : ViewModelProvider.Factory {
         if (modelClass.isAssignableFrom(CommunityDetailViewModel::class.java)) {
             return CommunityDetailViewModel(
                 UpdateBoardScrapUseCase(boardScrapRepository),
-                RemoveBoardUseCase(repository)
+                RemoveBoardUseCase(repository),
+                UpdateBoardLikeUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailFactory.kt
@@ -27,7 +27,8 @@ class CommunityDetailFactory : ViewModelProvider.Factory {
             return CommunityDetailViewModel(
                 UpdateBoardScrapUseCase(boardScrapRepository),
                 RemoveBoardUseCase(repository),
-                UpdateBoardLikeUseCase(repository)
+                UpdateBoardLikeUseCase(repository),
+                GetAllBoardsUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailFactory.kt
@@ -8,6 +8,7 @@ import kr.sparta.tripmate.data.repository.community.FirebaseBoardScrapRepository
 import kr.sparta.tripmate.domain.repository.community.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.repository.community.FirebaseBoardScrapRepository
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetAllBoardsUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetBoardUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.RemoveBoardUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardLikeUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardScrapUseCase
@@ -28,7 +29,7 @@ class CommunityDetailFactory : ViewModelProvider.Factory {
                 UpdateBoardScrapUseCase(boardScrapRepository),
                 RemoveBoardUseCase(repository),
                 UpdateBoardLikeUseCase(repository),
-                GetAllBoardsUseCase(repository)
+                GetBoardUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailViewModel.kt
@@ -3,24 +3,29 @@ package kr.sparta.tripmate.ui.viewmodel.community.detail
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kr.sparta.tripmate.domain.model.community.CommunityEntity
+import kr.sparta.tripmate.domain.model.community.toEntity
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetAllBoardsUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.RemoveBoardUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardLikeUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardScrapUseCase
 
 class CommunityDetailViewModel(
     private val updateBoardScrapUseCase: UpdateBoardScrapUseCase,
-    private val removeBoardUseCase: RemoveBoardUseCase
+    private val removeBoardUseCase: RemoveBoardUseCase,
+    private val updateBoardLikeUseCase: UpdateBoardLikeUseCase,
+    private val getAllBoardsUseCase: GetAllBoardsUseCase
 ) : ViewModel() {
     // DetailPage 내부에서만 사용하는 현재 BoardScrap여부
     private val _isBoardScrap = MutableLiveData<Boolean>()
-    val isBoardScrap: LiveData<Boolean> get() = _isBoardScrap
-
     /**
-     * 작성자: 서정한
-     * 내용: 게시물 스크랩버튼의 현재 토글여부를 업데이트합니다.
-     * */
-    fun updateIsBoardScrap(isBoardScrap: Boolean) {
-        _isBoardScrap.value = isBoardScrap
-    }
+     * 작성자 : 박성수
+     * 내용 : 게시물 목록
+     */
+    private val _boards: MutableLiveData<List<CommunityEntity?>> = MutableLiveData()
+    val boards get() = _boards
 
     /**
      * 작성자: 서정한
@@ -33,4 +38,13 @@ class CommunityDetailViewModel(
      * 내용: 선택한 게시글을 삭제합니다.
      * */
     fun removeBoard(key: String) = removeBoardUseCase(key)
+
+    /**
+     * 작성자 : 박성수
+     * 내용 : 좋아요 버튼 기능을 담당합니다.
+     */
+    fun updateBoardLike(uid: String, model: CommunityEntity) = viewModelScope.launch {
+        updateBoardLikeUseCase(uid, model.key?:"")
+    }
+
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailViewModel.kt
@@ -1,13 +1,12 @@
 package kr.sparta.tripmate.ui.viewmodel.community.detail
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.community.CommunityEntity
 import kr.sparta.tripmate.domain.model.community.toEntity
-import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetAllBoardsUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetBoardUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.RemoveBoardUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardLikeUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardScrapUseCase
@@ -16,15 +15,14 @@ class CommunityDetailViewModel(
     private val updateBoardScrapUseCase: UpdateBoardScrapUseCase,
     private val removeBoardUseCase: RemoveBoardUseCase,
     private val updateBoardLikeUseCase: UpdateBoardLikeUseCase,
-    private val getAllBoardsUseCase: GetAllBoardsUseCase
+    private val getBoardUseCase: GetBoardUseCase
 ) : ViewModel() {
-    // DetailPage 내부에서만 사용하는 현재 BoardScrap여부
-    private val _isBoardScrap = MutableLiveData<Boolean>()
+
     /**
      * 작성자 : 박성수
      * 내용 : 게시물 목록
      */
-    private val _boards: MutableLiveData<List<CommunityEntity?>> = MutableLiveData()
+    private val _boards: MutableLiveData<CommunityEntity?> = MutableLiveData()
     val boards get() = _boards
 
     /**
@@ -44,11 +42,12 @@ class CommunityDetailViewModel(
      * 내용 : 좋아요 버튼 기능을 담당합니다.
      */
     fun updateBoardLike(uid: String, model: CommunityEntity) = viewModelScope.launch {
-        updateBoardLikeUseCase(uid, model.key?:"")
+        updateBoardLikeUseCase(uid, model.key ?: "")
     }
-    suspend fun getAllBoards(){
-        getAllBoardsUseCase.invoke().collect() {
-            _boards.value = it.toEntity()
+
+    suspend fun getBoard(key: String) {
+        getBoardUseCase(key).collect(){
+            _boards.value = it?.toEntity()
         }
     }
 

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/detail/CommunityDetailViewModel.kt
@@ -46,5 +46,10 @@ class CommunityDetailViewModel(
     fun updateBoardLike(uid: String, model: CommunityEntity) = viewModelScope.launch {
         updateBoardLikeUseCase(uid, model.key?:"")
     }
+    suspend fun getAllBoards(){
+        getAllBoardsUseCase.invoke().collect() {
+            _boards.value = it.toEntity()
+        }
+    }
 
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/write/CommunityWriteViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/write/CommunityWriteViewModel.kt
@@ -92,11 +92,6 @@ class CommunityWriteViewModel(
                 setAddLoadingState(false)
             }else setEditLoadingState(false)
 
-            if (useCase == updateBoardUseCase::invoke) {
-                val intent = CommunityDetailActivity.newIntentForEntity(context, newItem)
-                (context as Activity).setResult(RESULT_OK, intent)
-            }
-
             isWindowTouchable(context, false)
             (context as Activity).finish()
         }

--- a/app/src/main/res/drawable/arrow_left.xml
+++ b/app/src/main/res/drawable/arrow_left.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/white"
+        android:fillColor="@color/black"
         android:pathData="M4,12L3.293,11.293L2.586,12L3.293,12.707L4,12ZM19,13C19.552,13 20,12.552 20,12C20,11.448 19.552,11 19,11V13ZM9.293,5.293L3.293,11.293L4.707,12.707L10.707,6.707L9.293,5.293ZM3.293,12.707L9.293,18.707L10.707,17.293L4.707,11.293L3.293,12.707ZM4,13H19V11H4V13Z" />
 </vector>

--- a/app/src/main/res/layout/activity_community_detail.xml
+++ b/app/src/main/res/layout/activity_community_detail.xml
@@ -18,7 +18,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:navigationIcon="@drawable/arrow_left">
+            app:navigationIcon="@drawable/arrow_left_white">
 
             <ImageView
                 android:id="@+id/community_detail_like_btn"

--- a/app/src/main/res/layout/activity_community_write.xml
+++ b/app/src/main/res/layout/activity_community_write.xml
@@ -13,7 +13,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="@drawable/arrow_left"
+        app:navigationIcon="@drawable/arrow_left_white"
         android:background="@color/primary">
 
         <TextView

--- a/app/src/main/res/layout/homebudgetitem.xml
+++ b/app/src/main/res/layout/homebudgetitem.xml
@@ -50,7 +50,7 @@
 
             <TextView
                 android:id="@+id/textView"
-                android:layout_width="wrap_content"
+                android:layout_width="70dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
                 android:text="원금"
@@ -61,10 +61,10 @@
 
             <TextView
                 android:id="@+id/home_budget_item_status_before_textview"
-                android:layout_width="wrap_content"
+                android:layout_width="130dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="33dp"
                 android:fontFamily="@font/inter"
+                android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/black"
                 android:textSize="15sp"
@@ -80,7 +80,7 @@
 
             <TextView
                 android:id="@+id/textView2"
-                android:layout_width="wrap_content"
+                android:layout_width="70dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
                 android:text="남은 예산"
@@ -91,9 +91,10 @@
 
             <TextView
                 android:id="@+id/home_budget_item_status_after_textview"
-                android:layout_width="wrap_content"
+                android:layout_width="130dp"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter"
+                android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/black"
                 android:textSize="15sp"


### PR DESCRIPTION
## 📌Linked Issues

- #188 

## ✏Change Details

- home의 가계부 탭에서 원금&예산 레이아웃이 불규칙적이던 부분을 수정했습니다.
- community/detail : 좋아요 기능을 추가했습니다.
- community/detail : 프로필 사진을 눌렀을때 userpage로 이동 되는 기능을 추가했습니다.
- community/detail : intent를 이용해서 데이터를 받아오는 방식에서 RDB에서 직접 받아오는 방식으로 수정했습니다.
- community/detail : 데이터소스에서 데이터를 받아온 후 라이브데이터로 그 중 한개만 관리합니다.
- community/detail : 구조를 바꾸면서 1차적으로 리팩토링했습니다.
- userprofile : 좋아요 기능 충돌되는 부분을 해결했습니다.
- setting : 뒤로가기 버튼을 검은색으로 변경합니다.

## 💬Comment

- 전체적으로 게시글과 관련된 부분 체크 한번씩 부탁드립니다.
- community 상세페이지의 구조를 intent -> RDB로 변경해서 혹시 정상작동 하지않을 수 있으니 테스트 부탁드립니다.(1차적으로 테스트는 했습니다.)
- setting 페이지에서 뒤로가기버튼 색상 확인 부탁드려요
- home화면 에뮬레이터말고 휴대폰에서 정상적으로 레이아웃배치되는지 확인 부탁드립니다.
- userprofile 좋아요 기능이 게시판을 쓰는 다른페이지에서 충돌이없는지 확인부탁드립니다.

## 📑References

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
