### PR TITLE
login페이지: 리펙토링

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/data/model/community/CommunityModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/model/community/CommunityModel.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
  * */
 @Parcelize
 data class CommunityModel(
-    val id: String?, // 게시글 id
+    val userid: String?, // 게시글 id
     val key: String?, // 게시판 Unique key
     val title: String?, // 제목
     val content: String?, // 게시글 내용

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/user/FirebaseUserRepositoryImpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/user/FirebaseUserRepositoryImpl.kt
@@ -2,8 +2,12 @@ package kr.sparta.tripmate.data.repository.user
 
 import android.content.Context
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
+import kr.sparta.tripmate.data.model.user.UserData
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
+import kr.sparta.tripmate.domain.model.user.toModel
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 
 /**
@@ -12,19 +16,11 @@ import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
  * */
 class FirebaseUserRepositoryImpl(private val remoteSource: FirebaseUserRemoteDataSource) :
     FirebaseUserRepository {
-    override fun updateUserData(uid: String, userLiveData: MutableLiveData<UserDataEntity?>) {
-        remoteSource.updateUserData(uid, userLiveData)
-    }
+    override fun getUserData(uid: String): Flow<UserData> = remoteSource.getUserData(uid)
 
-    override fun saveUserData(
-        model: UserDataEntity,
-        context: Context,
-        userLiveData: MutableLiveData<UserDataEntity?>
-    ) {
-        remoteSource.saveUserData(model, context, userLiveData)
-    }
+    override fun saveUserData(model: UserDataEntity) = remoteSource.saveUserData(model.toModel())
 
-    override fun resignUserData(context: Context) {
-        remoteSource.resignUserData(context)
-    }
+    override fun updateUserData(model: UserDataEntity) = remoteSource.saveUserData(model.toModel())
+
+    override fun withdrawalUserData(uid: String) = remoteSource.withdrawalUserData(uid)
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/community/CommunityEntity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/community/CommunityEntity.kt
@@ -6,7 +6,7 @@ import kr.sparta.tripmate.util.ScrapInterface
 
 @Parcelize
 data class CommunityEntity(
-    val id: String?, // 게시글 id
+    val userid: String?, // 게시글 id
     val key: String?, // 게시판 Unique key
     val title: String?, // 제목
     val content: String?, // 게시글 내용

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/community/FirebaseCommunityMapper.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/community/FirebaseCommunityMapper.kt
@@ -3,7 +3,7 @@ package kr.sparta.tripmate.domain.model.community
 import kr.sparta.tripmate.data.model.community.CommunityModel
 
 fun CommunityModel.toEntity(): CommunityEntity = CommunityEntity(
-    id = id,// 게시글 id
+    userid = userid,// 게시글 id
     title = title, // 제목
     content = content, // 게시글 내용
     profileNickname = profileNickname, // 프로필 닉네임
@@ -18,7 +18,7 @@ fun CommunityModel.toEntity(): CommunityEntity = CommunityEntity(
 )
 
 fun CommunityEntity.toModel() = CommunityModel(
-    id = id,// 게시글 id
+    userid = userid,// 게시글 id
     title = title, // 제목
     content = content, // 게시글 내용
     profileNickname = profileNickname, // 프로필 닉네임

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/user/UserDataEntity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/user/UserDataEntity.kt
@@ -5,10 +5,10 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class UserDataEntity(
-    val login_type : String? = null,
-    val login_Id: String? = null,       //로그인 id
-    val login_NickName: String? = null, //닉네임
-    val login_profile: String? = null,  //프로필사진
-    val login_Uid: String? = null,      //고유키값
-    val login_coment: String? = null    //자기소개
+    val type : String? = null,
+    val email: String? = null,       //로그인 id
+    val nickname: String? = null, //닉네임
+    val profileImg: String? = null,  //프로필사진
+    val uid: String? = null,      //고유키값
+    val comment: String? = null    //자기소개
 ) : Parcelable

--- a/app/src/main/java/kr/sparta/tripmate/domain/model/user/UserDataMapper.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/model/user/UserDataMapper.kt
@@ -3,12 +3,21 @@ package kr.sparta.tripmate.domain.model.user
 import kr.sparta.tripmate.data.model.user.UserData
 
 fun UserData.toEntity() = UserDataEntity(
-    login_type = login_type,
-    login_Id = login_Id,
-    login_NickName = login_NickName,
-    login_Uid = login_Uid,
-    login_profile = login_profile,
-    login_coment = login_coment
+    type = login_type,
+    email = login_Id,
+    nickname = login_NickName,
+    uid = login_Uid,
+    profileImg = login_profile,
+    comment = login_coment
+)
+
+fun UserDataEntity.toModel() = UserData(
+    login_type = type,
+    login_Id = email,
+    login_NickName = nickname,
+    login_Uid = uid,
+    login_profile = profileImg,
+    login_coment = comment
 )
 
 fun List<UserData>.toEntity() :List<UserDataEntity>{

--- a/app/src/main/java/kr/sparta/tripmate/domain/repository/user/FirebaseUserRepository.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/repository/user/FirebaseUserRepository.kt
@@ -1,7 +1,8 @@
 package kr.sparta.tripmate.domain.repository.user
 
 import android.content.Context
-import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.flow.Flow
+import kr.sparta.tripmate.data.model.user.UserData
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
 
 /**
@@ -9,15 +10,11 @@ import kr.sparta.tripmate.domain.model.user.UserDataEntity
  * 내용: 유저 Repository
  * */
 interface FirebaseUserRepository {
-    fun updateUserData(
-        uid: String, userLiveData: MutableLiveData<UserDataEntity?>
-    )
+    fun getUserData(uid: String): Flow<UserData>
 
-    fun saveUserData(
-        model: UserDataEntity, context: Context, userLiveData: MutableLiveData<UserDataEntity?>
-    )
+    fun saveUserData(model: UserDataEntity)
 
-    fun resignUserData(
-        context: Context
-    )
+    fun updateUserData(model: UserDataEntity)
+
+    fun withdrawalUserData(uid: String)
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/GetUserDataUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/GetUserDataUseCase.kt
@@ -1,0 +1,11 @@
+package kr.sparta.tripmate.domain.usecase.firebaseuserrepository
+
+import kotlinx.coroutines.flow.Flow
+import kr.sparta.tripmate.data.model.user.UserData
+import kr.sparta.tripmate.domain.model.user.UserDataEntity
+import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
+
+class GetUserDataUseCase(private val repository: FirebaseUserRepository) {
+
+    operator fun invoke(uid: String): Flow<UserData> = repository.getUserData(uid)
+}

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/SaveUserDataUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/SaveUserDataUseCase.kt
@@ -5,11 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 
-class SaveUserData(private val repository: FirebaseUserRepository) {
-    operator fun invoke(
-        model: UserDataEntity, context: Context, userLiveData:
-        MutableLiveData<UserDataEntity?>
-    ) {
-        repository.saveUserData(model, context, userLiveData)
+class SaveUserDataUseCase(private val repository: FirebaseUserRepository) {
+    operator fun invoke(model: UserDataEntity) {
+        repository.saveUserData(model)
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/UpdateUserDataUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/UpdateUserDataUseCase.kt
@@ -4,10 +4,6 @@ import androidx.lifecycle.MutableLiveData
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 
-class UpdateUserData(private val repository: FirebaseUserRepository) {
-    operator fun invoke(
-        uid: String, userLiveData:
-        MutableLiveData<UserDataEntity?>
-    ) =
-        repository.updateUserData(uid,userLiveData)
+class UpdateUserDataUseCase(private val repository: FirebaseUserRepository) {
+    operator fun invoke(model: UserDataEntity) = repository.saveUserData(model)
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/WithdrawalUserDataUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/WithdrawalUserDataUseCase.kt
@@ -3,8 +3,8 @@ package kr.sparta.tripmate.domain.usecase.firebaseuserrepository
 import android.content.Context
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 
-class ResignUserData(private val repository: FirebaseUserRepository) {
-    operator fun invoke(context: Context){
-        repository.resignUserData(context)
+class WithdrawalUserDataUseCase(private val repository: FirebaseUserRepository) {
+    operator fun invoke(uid: String){
+        repository.withdrawalUserData(uid)
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityDetailActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityDetailActivity.kt
@@ -255,7 +255,7 @@ class CommunityDetailActivity : AppCompatActivity() {
      * */
     private fun checkIsMyPost(model: CommunityEntity) = with(binding) {
         val uid = SharedPreferences.getUid(this@CommunityDetailActivity)
-        if (model.id == uid) {
+        if (model.userid == uid) {
             communityDetailEdit.visibility = View.VISIBLE
             communityDetailRemove.visibility = View.VISIBLE
         } else {

--- a/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityWriteActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/community/CommunityWriteActivity.kt
@@ -141,7 +141,7 @@ class CommunityWriteActivity : AppCompatActivity() {
                 likeUsers: List<String>
             ): CommunityEntity =
                 CommunityEntity(
-                    id = SharedPreferences.getUid(this@CommunityWriteActivity),
+                    userid = SharedPreferences.getUid(this@CommunityWriteActivity),
                     key = model?.key ?: key,
                     title = binding.communityWriteTitle.text.toString(),
                     content = binding.communityWriteDescription.text.toString(),

--- a/app/src/main/java/kr/sparta/tripmate/ui/community/main/CommunityFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/community/main/CommunityFragment.kt
@@ -3,7 +3,6 @@ package kr.sparta.tripmate.ui.community.main
 import android.app.Activity
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -77,7 +76,7 @@ class CommunityFragment : Fragment() {
             { model, position ->
                 // 유저프로필 클릭시 유저정보페이지로 이동.
                 // 단 내 프로필일경우 myPage로 이동.
-                if (model.id == uid) {
+                if (model.userid == uid) {
                     (activity).moveTabFragment(R.string.main_tab_title_mypage)
                 } else {
                     val intent = UserProfileActivity.newIntentForGetUserProfile(

--- a/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
@@ -5,10 +5,11 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.core.widget.doAfterTextChanged
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -21,6 +22,8 @@ import kr.sparta.tripmate.R
 import kr.sparta.tripmate.databinding.ActivityLoginBinding
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
 import kr.sparta.tripmate.ui.main.MainActivity
+import kr.sparta.tripmate.ui.viewmodel.login.LoginFactory
+import kr.sparta.tripmate.ui.viewmodel.login.LoginViewModel
 import kr.sparta.tripmate.util.method.longToast
 import kr.sparta.tripmate.util.method.shortToast
 import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
@@ -33,13 +36,125 @@ class LoginActivity : AppCompatActivity() {
     private lateinit var login_Database: DatabaseReference
     private lateinit var auth: FirebaseAuth
     private val binding by lazy { ActivityLoginBinding.inflate(layoutInflater) }
-    private var isLogin = false
+    private val viewModel: LoginViewModel by viewModels() {
+        LoginFactory()
+    }
+
     private val googleLogin: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            /**
+             * 작성자: 박성수
+             * 내용: 로그인 성공시 혹은 실패시 보여줄 레이아웃의 Visible을 로그인 성공여부에따라 반응함
+             * */
+            fun layoutVisibleController(isLoginSuccessful: Boolean) = with(binding) {
+                if (isLoginSuccessful) {
+                    loginCenterConstraint.visibility = View.GONE
+                    nickCenterConstraint.visibility = View.VISIBLE
+                    shortToast("닉네임을 입력해주세요")
+                } else {
+                    loginCenterConstraint.visibility = View.VISIBLE
+                    nickCenterConstraint.visibility = View.GONE
+                    shortToast("인증에 실패 했습니다.")
+                }
+            }
+
+            /**
+             * 작성자: 박성수
+             * 내용: 구글에서 발급한 토큰으로 Firebase Auth 인증 시작.
+             * */
+            fun firebaseAuthWithGoogle(idToken: String) {
+                /**
+                 * 작성자: 서정한
+                 * 내용: 사용자가 닉네임입력후 사용자 정보를 저장함. 이후 MainActivity로 이동.
+                 * */
+                fun confirmNickname() {
+                    binding.nickBtn.setOnClickListener {
+                        val nickname = binding.nickEdit.text.toString()
+
+                        if (nickname.trim().isEmpty()) {
+                            shortToast(getString(R.string.login_exception_empty_nickname))
+                            return@setOnClickListener
+                        }
+
+                        viewModel.getCurrentUser()?.let { user ->
+                            // 서버 업로드
+                            viewModel.saveCurrentUser(
+                                model = UserDataEntity(
+                                    type = "Google",
+                                    email = user.email.toString(),
+                                    nickname = nickname,
+                                    profileImg = user.photoUrl?.toString(),
+                                    uid = user.uid,
+                                    comment = "",
+                                )
+                            )
+
+                            // 기기 저장
+                            SharedPreferences.apply {
+                                // uid
+                                saveUid(
+                                    this@LoginActivity,
+                                    user.uid
+                                )
+                                // profile Image
+                                user.photoUrl?.toString()?.let { url ->
+                                    saveProfile(this@LoginActivity, url)
+                                }
+                                // nickname
+                                saveNickName(
+                                    this@LoginActivity,
+                                    nickname
+                                )
+                            }
+
+                            longToast("${nickname}의 계정으로 로그인 되었습니다.")
+                            startActivity(Intent(this, MainActivity::class.java))
+                            finish()
+                        }
+                    }
+                }
+
+                //구글에서 보내준 토큰을 이용해 유저를 구분하고, 파이어베이스에 로그인을 시도한다.
+                val credential = GoogleAuthProvider.getCredential(
+                    idToken,
+                    null
+                )
+
+                //credential을 이용해서 firebase로 해당 유저를 로그인한다.
+                auth.signInWithCredential(credential)
+                    .addOnCompleteListener(this) { task ->
+                        // 로그인 성공여부에따른 화면분기점
+                        layoutVisibleController(task.isSuccessful)
+                        //
+                        confirmNickname()
+                    }
+            }
+
+            /**
+             * 작성자: 박성수
+             * 내용: 로그인요청결과 인증작업
+             * */
+            fun handleSignInResult(data: Intent) {
+                kotlin.runCatching {
+                    //구글 로그인 액티비티에서 반환된 data에서 사용자 정보를 불러온다.
+                    GoogleSignIn.getSignedInAccountFromIntent(data)
+
+                }
+                    .onSuccess { result ->
+                        val account = result.getResult(ApiException::class.java)
+                        account.idToken?.let { it ->
+                            //로그인에 성공했을때 구글에서 사용자를 구별할 수 있도록 보내주는 토큰이다. 위에 gso에 담긴 토큰값과 다른것이다.
+                            firebaseAuthWithGoogle(it)
+                        }
+                    }
+                    .onFailure {
+                        shortToast("Google sign in failed: ${it.message}")
+                    }
+            }
+
             if (result.resultCode == Activity.RESULT_OK) {
-                val data: Intent? = result.data
-                if (data != null) {
-                    handleSignInResult(data)
+                result.data?.let {
+                    handleSignInResult(it)
                 }
             }
         }
@@ -52,124 +167,35 @@ class LoginActivity : AppCompatActivity() {
         auth = FirebaseAuth.getInstance()
         login_Database = Firebase.database.reference
 
-        // 앱에 로그인 되어있는지 확인하고, 로그인 되어있다면 바로 MainActivity로 이동시킵니다.
-        val currentUser = auth.currentUser
+        initLogin()
+    }
 
-        if (currentUser != null) {
+    private fun initLogin() {
+        /**
+         * 작성쟈: 서정한
+         * 내용: 구글로그인 요청
+         * */
+        fun googleSignIn() {
+            val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestIdToken(getString(R.string.default_web_client_id))
+                .requestEmail()
+                .build()
+
+            val googleSignInClient = GoogleSignIn.getClient(this, gso)
+            val signInIntent = googleSignInClient.signInIntent
+            googleLogin.launch(signInIntent)
+        }
+
+        if (viewModel.getCurrentUser() != null) {
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             finish()
         }
 
-
         binding.loginGoogle.setOnClickListener {
-            signIn()
+            googleSignIn()
         }
     }
 
-    private fun signIn() {
-        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)  //기본 구글 로그인 옵션
-            .requestIdToken(getString(R.string.default_web_client_id))  //서버로 전송할  Google ID토큰 (파이어베이스 프로젝트에 할당된 id)
-            .requestEmail()
-            .build()
-
-        val googleSignInClient = GoogleSignIn.getClient(this, gso)  //구글 로그인 클라이언트
-        val signInIntent = googleSignInClient.signInIntent  //구글 로그인 클라이언트를 인텐트에 할당한다.
-        googleLogin.launch(signInIntent)    //할당된 인텐트를 이용해서 구글 로그인 액티비티를 시작한다.
-    }
-
-
-    private fun handleSignInResult(data: Intent) {
-        val task =
-            GoogleSignIn.getSignedInAccountFromIntent(data)  //구글 로그인 액티비티에서 반환된 data에서 사용자 정보를 불러온다.
-        try {
-            val account =
-                task.getResult(ApiException::class.java)  //task에서 불러온 사용자 정보를 account에 할당하고, 예외가 발생하면 바로 catch부분으로 넘어간다.(밑에줄 코드x)
-            firebaseAuthWithGoogle(account.idToken!!)   //로그인에 성공했을때 구글에서 사용자를 구별할 수 있도록 보내주는 토큰이다. 위에 gso에 담긴 토큰값과 다른것이다.
-        } catch (e: ApiException) {
-            shortToast("Google sign in failed: ${e.message}")
-        }
-    }
-
-    private fun firebaseAuthWithGoogle(idToken: String) {
-        val credential = GoogleAuthProvider.getCredential(
-            idToken,
-            null
-        )    //구글에서 보내준 토큰을 이용해 유저를 구분하고, 파이어베이스에 로그인을 시도한다.
-        auth.signInWithCredential(credential)   //credential을 이용해서 firebase로 해당 유저를 로그인한다.
-            .addOnCompleteListener(this) { task ->      //로그인작업이 완료될때 리스너
-                if (task.isSuccessful) {
-                    SuccessLogin()
-                    shortToast("닉네임을 입력해주세요")
-
-                } else {
-                    FailLogin()
-                    shortToast("인증에 실패 했습니다.")
-                }
-            }
-    }
-
-    private fun savedLogin(
-        type: String,
-        id: String,
-        nickName: String,
-        photoUrl: String,
-        uid: String,
-        coment: String
-    ) {
-        Log.d("TripMates", "아이디 : ${id}")
-        Log.d("TripMates", "닉넴 : ${nickName}")
-        login_Database.child("UserData").child(uid).setValue(
-            UserDataEntity(
-                type, id, nickName, photoUrl,
-                uid, coment
-            )
-        )
-        SharedPreferences.apply {
-            saveUid(this@LoginActivity, uid)
-            saveProfile(this@LoginActivity, photoUrl)
-            saveNickName(this@LoginActivity, nickName)
-        }
-
-        startActivity(Intent(this, MainActivity::class.java))
-        finish()
-    }
-
-    private fun ChangeLayout(isLogin: Boolean) {
-        val nick_layout = binding.nickCenterConstraint
-        val login_layout = binding.loginCenterConstraint
-        if (isLogin) {
-            login_layout.visibility = View.GONE
-            nick_layout.visibility = View.VISIBLE
-
-            LoginBtn()
-        } else {
-            login_layout.visibility = View.VISIBLE
-            nick_layout.visibility = View.GONE
-        }
-
-    }
-
-    private fun LoginBtn() {
-        val user = auth.currentUser     //파이어베이스에 로그인한 사용자 정보
-        binding.nickBtn.setOnClickListener {
-            val input_nickName = binding.nickEdit.text.toString()
-            longToast("${input_nickName}의 계정으로 로그인 되었습니다.")
-            savedLogin(                                     //저장할 데이터들 함수로 보냄
-                "Google",user?.email.toString(), input_nickName,
-                user?.photoUrl?.toString() ?: "", user?.uid!!, ""
-            )
-        }
-    }
-
-    private fun SuccessLogin() {
-        isLogin = true
-        ChangeLayout(isLogin)
-    }
-
-    private fun FailLogin() {
-        isLogin = false
-        ChangeLayout(isLogin)
-    }
 
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/home/MyPageFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/home/MyPageFragment.kt
@@ -66,23 +66,21 @@ class MyPageFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        myPageViewModel.updateUserData(
+        myPageViewModel.getUserData(
             SharedPreferences.getUid(myPageContext)
-
-
         )
+
         initView()
         initViewModel()
-
     }
 
     private fun initViewModel() {
         with(myPageViewModel) {
             userData.observe(viewLifecycleOwner) {
                 with(binding) {
-                    mypageProfileImageview.load(it?.login_profile)
-                    mypageProfileNickTextview.text = it?.login_NickName
-                    mypageProfileContentTextview.text = it?.login_coment
+                    mypageProfileImageview.load(it?.profileImg)
+                    mypageProfileNickTextview.text = it?.nickname
+                    mypageProfileContentTextview.text = it?.comment
                 }
             }
         }
@@ -145,7 +143,6 @@ class MyPageFragment : Fragment() {
 
             val input_EditText = binding.mypageProfileContentEdittext.text.toString()
             myPageViewModel.saveUserData(
-                myPageContext,
                 UserDataEntity(
                     "Google",
                     user?.email.toString(), nickName,

--- a/app/src/main/java/kr/sparta/tripmate/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/setting/SettingActivity.kt
@@ -44,20 +44,19 @@ class SettingActivity : AppCompatActivity() {
         settingViewModel.settingUserData.observe(this) {
             setUpView(it)   //레이아웃에 데이터를 넣어줍니다.
 
-            deleteBtn()     //회원탈퇴 버튼입니다.
         }
     }
     //레이아웃에 데이터를 넣어줍니다.
     private fun setUpView(it: UserDataEntity?) {
-        binding.settingProfileImage.load(it?.login_profile)
-        binding.settingLoginType.text = it?.login_type
-        binding.settingId.text = it?.login_Id
+        binding.settingProfileImage.load(it?.profileImg)
+        binding.settingLoginType.text = it?.type
+        binding.settingId.text = it?.email
     }
 
     private fun initview() = with(binding) {
         //뷰모델 데이터를 가져옵니다.
         val uid = SharedPreferences.getUid(this@SettingActivity)
-        settingViewModel.updateUserData(uid)
+        settingViewModel.getUserData(uid)
 
         // 뒤로가기 버튼 입니다.
         settingToolbar.setNavigationOnClickListener {
@@ -70,11 +69,10 @@ class SettingActivity : AppCompatActivity() {
             shortToast("로그아웃 되었습니다.")
             moveLogin()
         }
-    }
-    // 회원탈퇴 버튼입니다.
-    private fun deleteBtn() {
+
+        // 회원탈퇴 버튼입니다.
         binding.settingWithdrawal.setOnClickListener {
-            settingViewModel.removeUserData(this)
+            settingViewModel.removeUserData(uid)
             auth.signOut()  //로그아웃 됩니다.
             moveLogin()     //회원탈퇴 후 로그인화면으로 이동됩니다.
         }

--- a/app/src/main/java/kr/sparta/tripmate/ui/userprofile/main/UserProfileActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/userprofile/main/UserProfileActivity.kt
@@ -49,7 +49,7 @@ class UserProfileActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-        model?.id?.let { SharedPreferences.saveUidFromUser(this, it) }
+        model?.userid?.let { SharedPreferences.saveUidFromUser(this, it) }
         initView()
         initViewModel()
         callDataSource()
@@ -57,7 +57,7 @@ class UserProfileActivity : AppCompatActivity() {
 
     private fun callDataSource() {
         model?.let {
-            model?.id?.let { it1 -> userProfileViewModel.updateUserData(it1) }
+            model?.userid?.let { it1 -> userProfileViewModel.getUserData(it1) }
         }
     }
 
@@ -65,9 +65,9 @@ class UserProfileActivity : AppCompatActivity() {
         with(userProfileViewModel) {
             userProfileResult.observe(this@UserProfileActivity) {
                 with(binding) {
-                    userProfileThumbnail.load(it?.login_profile)
-                    userProfileNickTextview.text = it?.login_NickName
-                    userProfileContentTextview.text = it?.login_coment
+                    userProfileThumbnail.load(it?.profileImg)
+                    userProfileNickTextview.text = it?.nickname
+                    userProfileContentTextview.text = it?.comment
                 }
             }
         }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
@@ -1,0 +1,24 @@
+package kr.sparta.tripmate.ui.viewmodel.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
+import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
+import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
+
+class LoginFactory : ViewModelProvider.Factory {
+    private val repository : FirebaseUserRepository by lazy {
+        FirebaseUserRepositoryImpl(FirebaseUserRemoteDataSource())
+    }
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if(modelClass.isAssignableFrom(LoginViewModel::class.java)){
+            return LoginViewModel(
+                SaveUserDataUseCase(repository)
+            ) as T
+        }
+        throw IllegalArgumentException("에러")
+    }
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
@@ -1,0 +1,28 @@
+package kr.sparta.tripmate.ui.viewmodel.login
+
+import androidx.lifecycle.ViewModel
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import kr.sparta.tripmate.domain.model.user.UserDataEntity
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
+
+class LoginViewModel(
+    private val saveUserDataUseCase: SaveUserDataUseCase
+) :
+    ViewModel() {
+    private val auth = FirebaseAuth.getInstance()
+
+    /**
+     * 작성자: 서정한
+     * 내용: 사용자가 Firebase에 등록되어있는지 확인함.
+     * 없을경우 null을 return함.
+     * */
+    fun getCurrentUser(): FirebaseUser? = auth.currentUser
+
+    /**
+     * 작성자: 서정한
+     * 내용: Firebase RDB에 로그인한 유저정보를 저장함.
+     * */
+    fun saveCurrentUser(model: UserDataEntity) = saveUserDataUseCase(model)
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/board/MyPageBoardViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/board/MyPageBoardViewModel.kt
@@ -26,7 +26,7 @@ class MyPageBoardViewModel(
      * */
     fun getAllMyBoards(uid: String)= CoroutineScope(Dispatchers.Main).launch {
         getAllBoardsUseCase().collect() { boards ->
-            val myBoard = boards.filter { it?.id == uid }
+            val myBoard = boards.filter { it?.userid == uid }
 
             _myBoards.value = myBoard.toEntity()
         }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/main/MyPageFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/main/MyPageFactory.kt
@@ -5,19 +5,20 @@ import androidx.lifecycle.ViewModelProvider
 import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
 import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserData
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserData
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class MyPageFactory : ViewModelProvider.Factory {
-    private val repository : FirebaseUserRepository by lazy {
+    private val repository: FirebaseUserRepository by lazy {
         FirebaseUserRepositoryImpl(FirebaseUserRemoteDataSource())
     }
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        if(modelClass.isAssignableFrom(MyPageViewModel::class.java)){
+        if (modelClass.isAssignableFrom(MyPageViewModel::class.java)) {
             return MyPageViewModel(
-                UpdateUserData(repository),
-                SaveUserData(repository)
+                GetUserDataUseCase(repository),
+                SaveUserDataUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/main/MyPageViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/main/MyPageViewModel.kt
@@ -3,22 +3,28 @@ package kr.sparta.tripmate.ui.viewmodel.mypage.main
 import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserData
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserData
+import kr.sparta.tripmate.domain.model.user.toEntity
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class MyPageViewModel(
-    private val updateUserData: UpdateUserData,
-    private val saveUserData: SaveUserData
+    private val getUserDataUseCase: GetUserDataUseCase,
+    private val saveUserDataUseCase: SaveUserDataUseCase
 ) :
     ViewModel() {
     private val _userData: MutableLiveData<UserDataEntity?> = MutableLiveData()
     val userData get() = _userData
-    fun updateUserData(uid: String) {
-        updateUserData(uid, _userData)
+
+    fun getUserData(uid: String) = viewModelScope.launch {
+        getUserDataUseCase(uid).collect(){
+            _userData.value = it.toEntity()
+        }
     }
 
-    fun saveUserData(context: Context, model: UserDataEntity) {
-        saveUserData(model, context, _userData)
-    }
+    fun saveUserData(model: UserDataEntity) = saveUserDataUseCase(model)
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingFactory.kt
@@ -2,13 +2,13 @@ package kr.sparta.tripmate.ui.viewmodel.setting
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import kr.sparta.tripmate.data.datasource.remote.community.FirebaseBoardRemoteDataSource
 import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
 import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.ResignUserData
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserData
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserData
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.WithdrawalUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class SettingFactory : ViewModelProvider.Factory {
     private val repository: FirebaseUserRepository by lazy {
@@ -18,9 +18,10 @@ class SettingFactory : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(SettingViewModel::class.java)) {
             return SettingViewModel(
-                UpdateUserData(repository),
-                SaveUserData(repository),
-                ResignUserData(repository)
+                GetUserDataUseCase(repository),
+                UpdateUserDataUseCase(repository),
+                SaveUserDataUseCase(repository),
+                WithdrawalUserDataUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingViewModel.kt
@@ -3,28 +3,32 @@ package kr.sparta.tripmate.ui.viewmodel.setting
 import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.ResignUserData
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserData
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserData
+import kr.sparta.tripmate.domain.model.user.toEntity
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.WithdrawalUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class SettingViewModel(
-    private val updateUserData: UpdateUserData,
-    private val saveUserData: SaveUserData,
-    private val resignUserData: ResignUserData
+    private val getUserDataUseCase: GetUserDataUseCase,
+    private val updateUserData: UpdateUserDataUseCase,
+    private val saveUserDataUseCase: SaveUserDataUseCase,
+    private val withdrawalUserDataUseCase: WithdrawalUserDataUseCase
 ) : ViewModel() {
     private val _settingUserData: MutableLiveData<UserDataEntity?> = MutableLiveData()
     val settingUserData get() = _settingUserData
 
-    fun updateUserData(uid: String) {
-        updateUserData(uid, _settingUserData)
+    fun getUserData(uid: String) = viewModelScope.launch{
+        getUserDataUseCase(uid).collect() {
+            _settingUserData.value = it.toEntity()
+        }
     }
 
-    fun saveUserData(model: UserDataEntity, context: Context) {
-        saveUserData(model, context, _settingUserData)
-    }
+    fun saveUserData(model: UserDataEntity) = saveUserDataUseCase(model)
 
-    fun removeUserData(context: Context) {
-        resignUserData(context)
-    }
+    fun removeUserData(uid: String) = withdrawalUserDataUseCase(uid)
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileBoardViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileBoardViewModel.kt
@@ -1,19 +1,14 @@
 package kr.sparta.tripmate.ui.viewmodel.userproflie
 
-import android.content.Context
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.community.CommunityEntity
 import kr.sparta.tripmate.domain.model.community.toEntity
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetAllBoardsUseCase
-import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.AddBoardUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardLikeUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardViewsUseCase
 
@@ -27,7 +22,7 @@ class UserProfileBoardViewModel(
 
     fun getFirebaseBoardData(uid: String) = CoroutineScope(Dispatchers.Main).launch {
         getAllBoardsUseCase().collect() {userData ->
-            val filterData = userData.filter { it?.id == uid }
+            val filterData = userData.filter { it?.userid == uid }
             _userPage.value = filterData.toEntity()
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileFactory.kt
@@ -2,11 +2,11 @@ package kr.sparta.tripmate.ui.viewmodel.userproflie
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import kr.sparta.tripmate.data.datasource.remote.community.FirebaseBoardRemoteDataSource
 import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
 import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserData
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class UserProfileFactory : ViewModelProvider.Factory{
     private val repository : FirebaseUserRepository by lazy {
@@ -16,7 +16,7 @@ class UserProfileFactory : ViewModelProvider.Factory{
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if(modelClass.isAssignableFrom(UserProfileViewModel::class.java)){
             return UserProfileViewModel(
-                UpdateUserData(repository)
+                GetUserDataUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileViewModel.kt
@@ -2,14 +2,21 @@ package kr.sparta.tripmate.ui.viewmodel.userproflie
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserData
+import kr.sparta.tripmate.domain.model.user.toEntity
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
-class UserProfileViewModel(private val updateUserData: UpdateUserData) : ViewModel() {
+class UserProfileViewModel(private val getUserDataUseCase: GetUserDataUseCase) : ViewModel() {
     private val _userProfileResults: MutableLiveData<UserDataEntity?> = MutableLiveData()
     val userProfileResult get() = _userProfileResults
 
-    fun updateUserData(uid: String) {
-        updateUserData(uid, _userProfileResults)
+    fun getUserData(uid: String) =viewModelScope.launch {
+        getUserDataUseCase(uid).collect() {
+            _userProfileResults.value = it.toEntity()
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="click_on_the_image_to_search">이미지를 클릭하면 검색 됩니다!</string>
     <string name="scrap_recommand_text">은 어떤가요?</string>
     <string name="scrap_detail_no_move_page">현재 보고계신 글 외에 다른 페이지로 이동이 불가능합니다.</string>
+    <string name="login_exception_empty_nickname">닉네임을 입력해주세요</string>
 
     <string-array name="scrap_recommand_list">
         <item>울산 관광</item>


### PR DESCRIPTION
## 📌Linked Issues

- #188

## ✏Change Details

로그인 페이지

- 로그인 페이지의 비즈니스로직을 분리하였습니다.
- UserData, UserDataEntity의  프로퍼티명을 수정하였습니다.
- LoginViewModel과 Factory를 생성하여 비즈니스로직 옮겼습니다.

커뮤니티

- 커뮤니티 Model과 Entity의 id 프로퍼티 네임을 'userid'로 수정하였습니다.

기타

- 기존 UserRemoteSource 부분의 명칭 및 로직을 수정하였습니다.
- UserRepository 및 UseCase역시 RemoteSource에 맞게 수정하였습니다.

## 💬Comment

## 📑References

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
