### PR TITLE
홈 화면: 리펙토링

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -110,10 +110,6 @@ class HomeFragment : Fragment() {
         initViewModel()
     }
 
-    override fun onResume() {
-        super.onResume()
-    }
-
     private fun initView() = with(binding) {
         // 상단 프로필 이미지 && 닉네임
         val profileImg = SharedPreferences.getProfile(homeContext)

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -29,7 +29,6 @@
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:scaleType="centerCrop" />
-
         </androidx.cardview.widget.CardView>
 
         <LinearLayout
@@ -56,21 +55,25 @@
     <androidx.core.widget.NestedScrollView
         android:id="@+id/home_body_const_scroll"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="75dp"
-        app:layout_constraintTop_toTopOf="@+id/home_toolbar">
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/home_toolbar">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginTop="10dp"
             android:orientation="vertical">
 
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:layout_margin="14dp"
-                app:cardElevation="25dp"
-                app:cardCornerRadius="16dp">
+                app:cardCornerRadius="16dp"
+                app:cardElevation="5dp">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/scrap_const"
@@ -92,13 +95,12 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
-
                     <ImageView
                         android:id="@+id/home_arrow1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:src="@drawable/arrow_right"
                         android:layout_marginEnd="15dp"
+                        android:src="@drawable/arrow_right"
                         app:layout_constraintBottom_toBottomOf="@+id/home_view1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
@@ -107,9 +109,8 @@
                         android:id="@+id/home_view1"
                         android:layout_width="match_parent"
                         android:layout_height="2dp"
-                        android:layout_marginStart="15dp"
-                        android:layout_marginEnd="15dp"
-                        android:layout_marginTop="5dp"
+                        android:layout_marginHorizontal="15dp"
+                        android:layout_marginVertical="5dp"
                         android:background="@color/Brown100"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
@@ -120,6 +121,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="15dp"
+                        android:layout_marginTop="5dp"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/home_view1" />
@@ -130,9 +132,10 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:layout_margin="14dp"
-                app:cardElevation="25dp"
-                app:cardCornerRadius="16dp">
+                app:cardCornerRadius="16dp"
+                app:cardElevation="5dp">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/popular_const"
@@ -160,8 +163,8 @@
                         android:id="@+id/home_arrow2"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:src="@drawable/arrow_right"
                         android:layout_marginEnd="15dp"
+                        android:src="@drawable/arrow_right"
                         app:layout_constraintBottom_toTopOf="@+id/home_board_recyclerview"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="@+id/popular_const" />
@@ -170,9 +173,8 @@
                         android:id="@+id/home_view2"
                         android:layout_width="match_parent"
                         android:layout_height="2dp"
-                        android:layout_marginStart="15dp"
-                        android:layout_marginEnd="15dp"
-                        android:layout_marginTop="5dp"
+                        android:layout_marginHorizontal="15dp"
+                        android:layout_marginVertical="5dp"
                         android:background="@color/Brown100"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
@@ -183,6 +185,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="15dp"
+                        android:layout_marginTop="5dp"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/home_view2" />
@@ -194,9 +197,10 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:layout_margin="14dp"
-                app:cardElevation="25dp"
-                app:cardCornerRadius="16dp">
+                app:cardCornerRadius="16dp"
+                app:cardElevation="5dp">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/budget_const"
@@ -214,8 +218,8 @@
                         android:layout_marginStart="15dp"
                         android:layout_marginTop="5dp"
                         android:text="@string/budget_list_title"
-                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintBottom_toTopOf="@+id/home_view3"
+                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="@+id/budget_const" />
 
 
@@ -223,19 +227,18 @@
                         android:id="@+id/home_arrow3"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:src="@drawable/arrow_right"
                         android:layout_marginEnd="15dp"
-                        app:layout_constraintEnd_toEndOf="parent"
+                        android:src="@drawable/arrow_right"
                         app:layout_constraintBottom_toTopOf="@+id/home_budget_recyclerview"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="@+id/budget_const" />
 
                     <View
                         android:id="@+id/home_view3"
                         android:layout_width="match_parent"
                         android:layout_height="2dp"
-                        android:layout_marginStart="15dp"
-                        android:layout_marginEnd="15dp"
-                        android:layout_marginTop="5dp"
+                        android:layout_marginHorizontal="15dp"
+                        android:layout_marginVertical="5dp"
                         android:background="@color/Brown100"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
@@ -246,6 +249,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="180dp"
                         android:layout_marginStart="15dp"
+                        android:layout_marginTop="5dp"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/home_view3" />

--- a/app/src/main/res/layout/homebudgetitem.xml
+++ b/app/src/main/res/layout/homebudgetitem.xml
@@ -5,109 +5,120 @@
     android:id="@+id/home_budget_layout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_gravity="center_horizontal"
+    android:background="@drawable/background_budget_view_type5"
+    android:layout_marginEnd="15dp"
     android:paddingHorizontal="15dp"
-    android:paddingVertical="10dp"
-   android:layout_margin="10dp"
-    android:background="@drawable/background_budget_view_type5">
-    <LinearLayout
-        android:id="@+id/linearLayout"
+    android:paddingVertical="10dp">
+
+    <TextView
+        android:id="@+id/home_budget_item_title_textview"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="15dp"
+        android:layout_marginBottom="10dp"
+        android:background="@drawable/background_budget_view_type2"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:paddingHorizontal="15dp"
+        android:paddingVertical="7dp"
+        android:textColor="@color/white"
+        android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:id="@+id/home_budget_item_title_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="15dp"
-            android:layout_marginBottom="10dp"
-            android:background="@drawable/background_budget_view_type2"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:paddingHorizontal="15dp"
-            android:paddingVertical="7dp"
-            android:textColor="@color/white"
-            android:textSize="12sp"
-            app:layout_constraintStart_toStartOf="@+id/view"
-            app:layout_constraintTop_toTopOf="@+id/view"
-            tools:text="스페인  여행 가계부" />
-    </LinearLayout>
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="스페인  여행 가계부" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="10dp"
         android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="@+id/home_budget_layout"
-        app:layout_constraintStart_toStartOf="@+id/home_budget_layout"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout">
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/home_budget_item_title_textview"
+        >
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="200dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="10dp"
+            >
 
             <TextView
-                android:id="@+id/textView"
-                android:layout_width="70dp"
+                android:id="@+id/home_budget_amount"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
                 android:text="원금"
+                android:textAlignment="textStart"
                 android:textColor="#555555"
                 android:textSize="16sp"
-                app:layout_constraintStart_toStartOf="@+id/view2"
-                app:layout_constraintTop_toBottomOf="@+id/linearLayout" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/home_budget_item_status_before_textview"
-                android:layout_width="130dp"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/inter"
+                android:layout_marginStart="20dp"
                 android:ellipsize="end"
+                android:fontFamily="@font/inter"
                 android:maxLines="1"
+                android:textAlignment="textEnd"
                 android:textColor="@color/black"
                 android:textSize="15sp"
                 android:textStyle="bold"
-                tools:text="5,000,000,000 원" />
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/home_budget_amount"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="5,000,000 원" />
 
-        </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="200dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="10dp"
+            >
 
             <TextView
-                android:id="@+id/textView2"
-                android:layout_width="70dp"
+                android:id="@+id/home_remain_budget_text"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
                 android:text="남은 예산"
+                android:textAlignment="textStart"
                 android:textColor="#555555"
                 android:textSize="16sp"
-                app:layout_constraintStart_toStartOf="@+id/guideline2"
-                app:layout_constraintTop_toBottomOf="@+id/linearLayout" />
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
 
             <TextView
                 android:id="@+id/home_budget_item_status_after_textview"
-                android:layout_width="130dp"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/inter"
+                android:layout_marginStart="20dp"
                 android:ellipsize="end"
+                android:fontFamily="@font/inter"
                 android:maxLines="1"
+                android:textAlignment="textEnd"
                 android:textColor="@color/black"
                 android:textSize="15sp"
                 android:textStyle="bold"
-                tools:text="5,000,000,000 원" />
-
-        </LinearLayout>
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/home_remain_budget_text"
+                tools:text="5,000,000 원" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <View
             android:id="@+id/view2"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_margin="15dp"
+            android:layout_margin="10dp"
             android:background="@color/Gray300" />
 
         <TextView
@@ -121,14 +132,11 @@
             android:textSize="12sp"
             tools:text="2023.12.09 ~ 2023.12.21" />
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/home_budget_guideline2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintGuide_percent="0.5" />
-
+<!--        <androidx.constraintlayout.widget.Guideline-->
+<!--            android:id="@+id/home_budget_guideline2"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:orientation="vertical"-->
+<!--            app:layout_constraintGuide_percent="0.5" />-->
     </LinearLayout>
-
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/scraptitems.xml
+++ b/app/src/main/res/layout/scraptitems.xml
@@ -1,58 +1,67 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scrap_Grid_layout"
-    android:layout_width="190dp"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="10dp"
-    android:orientation="vertical"
-    android:layout_gravity="center_horizontal">
+    android:padding="10dp">
 
     <androidx.cardview.widget.CardView
         android:id="@+id/scrap_type_iconCardView"
-        android:layout_width="115dp"
-        android:layout_height="115dp"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
         android:layout_gravity="center"
         app:cardCornerRadius="35dp"
-        app:cardElevation="0dp">
-            <ImageView
-                android:id="@+id/scrap_image"
-                android:layout_width="115dp"
-                android:layout_height="115dp"
-                android:scaleType="centerCrop" />
+        app:cardElevation="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/scrap_image"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:scaleType="centerCrop"
+            tools:src="@color/primary" />
 
     </androidx.cardview.widget.CardView>
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        >
-        <TextView
-            android:id="@+id/scrap_title"
-            android:layout_width="150dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:textSize="15sp"
-            android:textStyle="bold"
-            android:layout_marginTop="10dp"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:textColor="@color/black" />
-        <ImageView
-            android:id="@+id/scrap_like"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
-            android:layout_marginHorizontal="5dp"
-            android:src="@drawable/ic_star"/>
-    </LinearLayout>
-
     <TextView
-        android:id="@+id/scrap_content"
+        android:id="@+id/scrap_title"
         android:layout_width="150dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:textSize="13sp"
+        android:layout_marginTop="10dp"
         android:ellipsize="end"
         android:maxLines="2"
-        android:textColor="@color/Gray600" />
-</LinearLayout>
+        android:textColor="@color/black"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/scrap_type_iconCardView"
+        tools:text="테스틈ㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㄹ" />
+
+    <ImageView
+        android:id="@+id/scrap_like"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:src="@drawable/ic_star"
+        app:layout_constraintBottom_toBottomOf="@+id/scrap_type_iconCardView"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/scrap_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textColor="@color/Gray600"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/scrap_title"
+        app:layout_constraintStart_toStartOf="@id/scrap_title"
+        app:layout_constraintTop_toBottomOf="@+id/scrap_title"
+        tools:text="내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용내용" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📌Linked Issues

- #197 

## ✏Change Details

 - 각 CardView의 Line Padding 조정하였습니다.
 - 스크롤시 툴바제외 컨텐츠 뒷배경쪽은 흰색으로 조정하였습니다.
 - CardView의 Recyclerview Bottom BottomNavigation으로 붙이는건 불가능해서 Cardview의 Shadow를 줄였습니다.
 - 가계부관리 가운데정렬하였습니다.
 - 블로그 Recyclerview Item 디자인 변경하였습니다.
 - 블로그 Recyclerview item 가운데정렬하였습니다.

## 💬Comment

## 📑References

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
