### PR TITLE
Login& Setting : 로그인&회원탈퇴&로그아웃 기능 

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
@@ -1,18 +1,15 @@
 package kr.sparta.tripmate.data.datasource.remote.user
 
-import android.content.Context
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.ktx.database
 import com.google.firebase.database.ktx.getValue
 import com.google.firebase.database.ktx.snapshots
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kr.sparta.tripmate.data.model.user.UserData
-import kr.sparta.tripmate.domain.model.user.toEntity
-import kr.sparta.tripmate.util.method.shortToast
-import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
+import kotlin.coroutines.resume
 
 /**
  * 작성자: 서정한
@@ -20,6 +17,10 @@ import kr.sparta.tripmate.util.sharedpreferences.SharedPreferences
  * */
 class FirebaseUserRemoteDataSource {
     private fun getReference() = Firebase.database.getReference("UserData")
+
+    private fun getNickReference() = Firebase.database.getReference("NickNameData")
+    private fun authReference() = FirebaseAuth.getInstance()
+
     /**
      * 작성자 : 서정한
      * 내용 : 유저정보를 가져옵니다.
@@ -36,21 +37,64 @@ class FirebaseUserRemoteDataSource {
      * 내용 : 유저정보를 저장합니다.
      * 자기소개를 수정하고 저장 후 업데이트 합니다.
      * 추후 프로필 사진을 수정하거나 다른 데이터를 수정해도 재사용 가능합니다.
+     *
+     * 추가 : 닉네임을 추가로 저장합니다. (닉네임 중복검사를 통해 닉네임을 누적저장합니다.)
      */
     fun saveUserData(model: UserData) {
-        val ref = model.login_Uid?.let { 
-            getReference().child(it) 
+        val ref = model.login_Uid?.let {
+            getReference().child(it)
         }
-        
+
+        val nickRef = getNickReference()
+        model.login_NickName?.let {
+            nickRef.get().addOnSuccessListener { snapshot ->
+                val nickList = snapshot.children.mapNotNull {
+                    it.getValue(String::class.java)
+                }.toMutableList()
+                nickList.add(model.login_NickName)
+                nickRef.setValue(nickList)
+            }
+        }
         ref?.setValue(model)
     }
 
     /**
      * 작성자 : 서정한
      * 내용 : 회원탈퇴.
+     *
+     * 추가 : RDB에서 삭제 하는 부분에서 auth에서 삭제하는 부분을 추가했습니다.
      */
     fun withdrawalUserData(uid: String) {
+        val user = authReference().currentUser
         val userRef = getReference().child(uid)
+        user?.delete()
         userRef.removeValue()
+    }
+
+    /**
+     * 작성자 : 박성수
+     * 내용 : 로그아웃을 합니다.
+     */
+
+    fun logout() = authReference().signOut()
+
+    /**
+     * 작성자 : 박성수
+     * 내용 : 따로 RDB에 저장된 닉네임 데이터를 불러옵니다.
+     * 불리언값을 이용해 앱을 실행하고 닉네임으 정할때 중복체크를 합니다.
+     */
+    suspend fun getNickNameData(nickName: String): Boolean {
+        val nickRef = getNickReference()
+
+            val result = suspendCancellableCoroutine<Boolean> {continuation ->
+                nickRef.get().addOnSuccessListener { snapshot ->
+                    val isExist = snapshot.children.mapNotNull {
+                        it.getValue(String::class.java)
+                    }.toMutableList().find { it == nickName }.isNullOrEmpty()
+                    continuation.resume(isExist)
+                }
+            }
+
+        return result
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
@@ -90,7 +90,7 @@ class FirebaseUserRemoteDataSource {
                 nickRef.get().addOnSuccessListener { snapshot ->
                     val isExist = snapshot.children.mapNotNull {
                         it.getValue(String::class.java)
-                    }.toMutableList().find { it == nickName }.isNullOrEmpty()
+                    }.toMutableList().find { it == nickName }.isNullOrBlank()
                     continuation.resume(isExist)
                 }
             }

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/user/FirebaseUserRepositoryImpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/user/FirebaseUserRepositoryImpl.kt
@@ -23,4 +23,8 @@ class FirebaseUserRepositoryImpl(private val remoteSource: FirebaseUserRemoteDat
     override fun updateUserData(model: UserDataEntity) = remoteSource.saveUserData(model.toModel())
 
     override fun withdrawalUserData(uid: String) = remoteSource.withdrawalUserData(uid)
+
+    override fun logout() = remoteSource.logout()
+
+    override suspend fun getNickNameData(nickName: String) : Boolean = remoteSource.getNickNameData(nickName)
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/repository/user/FirebaseUserRepository.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/repository/user/FirebaseUserRepository.kt
@@ -1,6 +1,5 @@
 package kr.sparta.tripmate.domain.repository.user
 
-import android.content.Context
 import kotlinx.coroutines.flow.Flow
 import kr.sparta.tripmate.data.model.user.UserData
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
@@ -17,4 +16,8 @@ interface FirebaseUserRepository {
     fun updateUserData(model: UserDataEntity)
 
     fun withdrawalUserData(uid: String)
+
+    fun logout()
+
+    suspend fun getNickNameData(nickname: String) : Boolean
 }

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/GetNickNameDataUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/GetNickNameDataUseCase.kt
@@ -1,0 +1,7 @@
+package kr.sparta.tripmate.domain.usecase.firebaseuserrepository
+
+import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
+
+class GetNickNameDataUseCase(private val repository: FirebaseUserRepository) {
+    operator suspend fun invoke(nickName: String): Boolean = repository.getNickNameData(nickName)
+}

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/LogoutUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/LogoutUseCase.kt
@@ -1,0 +1,7 @@
+package kr.sparta.tripmate.domain.usecase.firebaseuserrepository
+
+import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
+
+class LogoutUseCase(private val repository : FirebaseUserRepository) {
+    operator fun invoke() = repository.logout()
+}

--- a/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
@@ -9,7 +9,6 @@ import android.view.View
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.core.widget.doAfterTextChanged
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
@@ -18,6 +17,9 @@ import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.sparta.tripmate.R
 import kr.sparta.tripmate.databinding.ActivityLoginBinding
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
@@ -48,9 +50,18 @@ class LoginActivity : AppCompatActivity() {
              * */
             fun layoutVisibleController(isLoginSuccessful: Boolean) = with(binding) {
                 if (isLoginSuccessful) {
-                    loginCenterConstraint.visibility = View.GONE
-                    nickCenterConstraint.visibility = View.VISIBLE
-                    shortToast("닉네임을 입력해주세요")
+                    if (!SharedPreferences.getUid(this@LoginActivity).isNullOrEmpty()) {
+                        loginCenterConstraint.visibility = View.VISIBLE
+                        nickCenterConstraint.visibility = View.GONE
+                        shortToast("로그인 되었습니다.")
+                        val intent = Intent(this@LoginActivity, MainActivity::class.java)
+                        startActivity(intent)
+                        finish()
+                    } else {
+                        loginCenterConstraint.visibility = View.GONE
+                        nickCenterConstraint.visibility = View.VISIBLE
+                        shortToast("닉네임을 입력해주세요")
+                    }
                 } else {
                     loginCenterConstraint.visibility = View.VISIBLE
                     nickCenterConstraint.visibility = View.GONE
@@ -69,47 +80,53 @@ class LoginActivity : AppCompatActivity() {
                  * */
                 fun confirmNickname() {
                     binding.nickBtn.setOnClickListener {
-                        val nickname = binding.nickEdit.text.toString()
-
-                        if (nickname.trim().isEmpty()) {
-                            shortToast(getString(R.string.login_exception_empty_nickname))
-                            return@setOnClickListener
-                        }
-
-                        viewModel.getCurrentUser()?.let { user ->
-                            // 서버 업로드
-                            viewModel.saveCurrentUser(
-                                model = UserDataEntity(
-                                    type = "Google",
-                                    email = user.email.toString(),
-                                    nickname = nickname,
-                                    profileImg = user.photoUrl?.toString(),
-                                    uid = user.uid,
-                                    comment = "",
-                                )
-                            )
-
-                            // 기기 저장
-                            SharedPreferences.apply {
-                                // uid
-                                saveUid(
-                                    this@LoginActivity,
-                                    user.uid
-                                )
-                                // profile Image
-                                user.photoUrl?.toString()?.let { url ->
-                                    saveProfile(this@LoginActivity, url)
-                                }
-                                // nickname
-                                saveNickName(
-                                    this@LoginActivity,
-                                    nickname
-                                )
+                        CoroutineScope(Dispatchers.Main).launch{
+                            val nickName = binding.nickEdit.text.toString()
+                            val isExist = viewModel.getNickNameData(nickName)
+                            if (!isExist) {
+                                shortToast("닉네임이 존재합니다.")
+                                return@launch}
+                            if (nickName.trim().isEmpty()) {
+                                shortToast(getString(R.string.login_exception_empty_nickname))
+                                return@launch
                             }
 
-                            longToast("${nickname}의 계정으로 로그인 되었습니다.")
-                            startActivity(Intent(this, MainActivity::class.java))
+                            viewModel.getCurrentUser()?.let { user ->
+                                // 서버 업로드
+                                viewModel.saveCurrentUser(
+                                    model = UserDataEntity(
+                                        type = "Google",
+                                        email = user.email.toString(),
+                                        nickname = nickName,
+                                        profileImg = user.photoUrl?.toString(),
+                                        uid = user.uid,
+                                        comment = "",
+                                    )
+                                )
+
+                                // 기기 저장
+                                SharedPreferences.apply {
+                                    // uid
+                                    saveUid(
+                                        this@LoginActivity,
+                                        user.uid
+                                    )
+                                    // profile Image
+                                    user.photoUrl?.toString()?.let { url ->
+                                        saveProfile(this@LoginActivity, url)
+                                    }
+                                    // nickname
+                                    saveNickName(
+                                        this@LoginActivity,
+                                        nickName
+                                    )
+                                }
+
+                                longToast("${nickName}의 계정으로 로그인 되었습니다.")
+                        }
+                           startActivity( MainActivity.newIntent(this@LoginActivity))
                             finish()
+
                         }
                     }
                 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/login/LoginActivity.kt
@@ -50,10 +50,10 @@ class LoginActivity : AppCompatActivity() {
              * */
             fun layoutVisibleController(isLoginSuccessful: Boolean) = with(binding) {
                 if (isLoginSuccessful) {
-                    if (!SharedPreferences.getUid(this@LoginActivity).isNullOrEmpty()) {
+                    if (!SharedPreferences.getUid(this@LoginActivity).isNullOrBlank()) {
                         loginCenterConstraint.visibility = View.VISIBLE
                         nickCenterConstraint.visibility = View.GONE
-                        shortToast("로그인 되었습니다.")
+                        shortToast("${SharedPreferences.getNickName(this@LoginActivity)}의 계정으로 로그인 되었습니다.")
                         val intent = Intent(this@LoginActivity, MainActivity::class.java)
                         startActivity(intent)
                         finish()

--- a/app/src/main/java/kr/sparta/tripmate/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/setting/SettingActivity.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import coil.load
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.MobileAds
-import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
@@ -27,14 +27,12 @@ class SettingActivity : AppCompatActivity() {
 
     private val settingViewModel: SettingViewModel by viewModels { SettingFactory() }
     private lateinit var setting_Database: DatabaseReference
-    private lateinit var auth: FirebaseAuth
     private val binding by lazy {
         ActivitySettingBinding.inflate(layoutInflater)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        auth = FirebaseAuth.getInstance()
         setting_Database = Firebase.database.reference
         setContentView(binding.root)
 
@@ -68,15 +66,16 @@ class SettingActivity : AppCompatActivity() {
 
         // 로그아웃 버튼입니다.
         settingLogout.setOnClickListener {
-            auth.signOut()
+            settingViewModel.logout()
             shortToast("로그아웃 되었습니다.")
             moveLogin()
         }
 
         // 회원탈퇴 버튼입니다.
         binding.settingWithdrawal.setOnClickListener {
+            SharedPreferences.removeKey(this@SettingActivity)
             settingViewModel.removeUserData(uid)
-            auth.signOut()  //로그아웃 됩니다.
+            settingViewModel.logout() //로그아웃 됩니다.
             moveLogin()     //회원탈퇴 후 로그인화면으로 이동됩니다.
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
@@ -5,8 +5,9 @@ import androidx.lifecycle.ViewModelProvider
 import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
 import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetNickNameDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class LoginFactory : ViewModelProvider.Factory {
     private val repository : FirebaseUserRepository by lazy {
@@ -16,7 +17,9 @@ class LoginFactory : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if(modelClass.isAssignableFrom(LoginViewModel::class.java)){
             return LoginViewModel(
-                SaveUserDataUseCase(repository)
+                SaveUserDataUseCase(repository),
+                GetNickNameDataUseCase(repository),
+                GetUserDataUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
@@ -18,8 +18,7 @@ class LoginFactory : ViewModelProvider.Factory {
         if(modelClass.isAssignableFrom(LoginViewModel::class.java)){
             return LoginViewModel(
                 SaveUserDataUseCase(repository),
-                GetNickNameDataUseCase(repository),
-                GetUserDataUseCase(repository)
+                GetNickNameDataUseCase(repository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
@@ -1,17 +1,28 @@
 package kr.sparta.tripmate.ui.viewmodel.login
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
+import kr.sparta.tripmate.domain.model.user.toEntity
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetNickNameDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class LoginViewModel(
-    private val saveUserDataUseCase: SaveUserDataUseCase
+    private val saveUserDataUseCase: SaveUserDataUseCase,
+    private val getNickNameDataUseCase: GetNickNameDataUseCase,
+    private val getUserDataUseCase: GetUserDataUseCase
+
 ) :
     ViewModel() {
     private val auth = FirebaseAuth.getInstance()
+    private val _userDatas = MutableLiveData<UserDataEntity?>()
+    val userDatas : LiveData<UserDataEntity?> get() = _userDatas
 
     /**
      * 작성자: 서정한
@@ -25,4 +36,13 @@ class LoginViewModel(
      * 내용: Firebase RDB에 로그인한 유저정보를 저장함.
      * */
     fun saveCurrentUser(model: UserDataEntity) = saveUserDataUseCase(model)
+
+    suspend fun getNickNameData(nickName: String): Boolean =
+        getNickNameDataUseCase(nickName)
+
+   fun getUserData(uid: String) = viewModelScope.launch{
+       getUserDataUseCase(uid).collect() {
+           _userDatas.value = it.toEntity()
+       }
+    }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
@@ -15,8 +15,7 @@ import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseC
 
 class LoginViewModel(
     private val saveUserDataUseCase: SaveUserDataUseCase,
-    private val getNickNameDataUseCase: GetNickNameDataUseCase,
-    private val getUserDataUseCase: GetUserDataUseCase
+    private val getNickNameDataUseCase: GetNickNameDataUseCase
 
 ) :
     ViewModel() {

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
@@ -37,12 +37,5 @@ class LoginViewModel(
      * */
     fun saveCurrentUser(model: UserDataEntity) = saveUserDataUseCase(model)
 
-    suspend fun getNickNameData(nickName: String): Boolean =
-        getNickNameDataUseCase(nickName)
-
-   fun getUserData(uid: String) = viewModelScope.launch{
-       getUserDataUseCase(uid).collect() {
-           _userDatas.value = it.toEntity()
-       }
-    }
+    suspend fun getNickNameData(nickName: String): Boolean =  getNickNameDataUseCase(nickName)
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingFactory.kt
@@ -6,9 +6,8 @@ import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSour
 import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.LogoutUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.WithdrawalUserDataUseCase
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
-import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class SettingFactory : ViewModelProvider.Factory {
     private val repository: FirebaseUserRepository by lazy {
@@ -19,8 +18,7 @@ class SettingFactory : ViewModelProvider.Factory {
         if (modelClass.isAssignableFrom(SettingViewModel::class.java)) {
             return SettingViewModel(
                 GetUserDataUseCase(repository),
-                UpdateUserDataUseCase(repository),
-                SaveUserDataUseCase(repository),
+                LogoutUseCase(repository),
                 WithdrawalUserDataUseCase(repository)
             ) as T
         }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingViewModel.kt
@@ -9,16 +9,17 @@ import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
 import kr.sparta.tripmate.domain.model.user.toEntity
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.LogoutUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.WithdrawalUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.UpdateUserDataUseCase
 
 class SettingViewModel(
     private val getUserDataUseCase: GetUserDataUseCase,
-    private val updateUserData: UpdateUserDataUseCase,
-    private val saveUserDataUseCase: SaveUserDataUseCase,
-    private val withdrawalUserDataUseCase: WithdrawalUserDataUseCase
-) : ViewModel() {
+    private val logoutUseCase: LogoutUseCase,
+    private val withdrawalUserDataUseCase: WithdrawalUserDataUseCase,
+
+    ) : ViewModel() {
     private val _settingUserData: MutableLiveData<UserDataEntity?> = MutableLiveData()
     val settingUserData get() = _settingUserData
 
@@ -28,7 +29,8 @@ class SettingViewModel(
         }
     }
 
-    fun saveUserData(model: UserDataEntity) = saveUserDataUseCase(model)
 
     fun removeUserData(uid: String) = withdrawalUserDataUseCase(uid)
+
+    fun logout() = logoutUseCase()
 }

--- a/app/src/main/java/kr/sparta/tripmate/util/sharedpreferences/SharedPreferences.kt
+++ b/app/src/main/java/kr/sparta/tripmate/util/sharedpreferences/SharedPreferences.kt
@@ -49,4 +49,11 @@ object SharedPreferences {
         return spf.getString("uidFromUser", "") ?: ""
     }
 
+    fun removeKey(context: Context) {
+        val edit = context.getSharedPreferences(USER_KEY, Context.MODE_PRIVATE).edit()
+        edit.clear()
+        edit.commit()
+    }
+
+
 }


### PR DESCRIPTION
## 📌Linked Issues

- 해당이슈 링크 없을경우 생략가능

## ✏Change Details

- 회원탈퇴 시 기존에는 RDB에 저장된 UserData만 삭제 되었었는데, Auth에 저장된 User정보도 추가로 삭제됩니다.
- 회원탈퇴 시 SharedPreferences에 저장된 모든데이터가 삭제됩니다.
- Login : 로그아웃 후 재 접속할 때 닉네임을 다시 입력하지않고 바로 로그인이 됩니다.
- Login : 닉네임 입력 시 중복체크를 진행합니다.
- Login : 닉네임 입력 시 빈칸을 예외처리합니다.

## 💬Comment

- 로그아웃과 회원 탈퇴가 RDB와 Auth에서 모두 삭제되는지 확인 부탁드립니다.
- 로그아웃 후 재접속 시 바로 접속되는지 확인이 필요합니다.
- 회원탈퇴 & 처음 접속 시 닉네임을 중복체크하고 정상적으로 접속이 되는지 확인이 필요합니다.
- 닉네임 입력 시 빈칸으로 입력했을때 접속이 제한되는지 확인이 필요합니다.

## 📑References


## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
