### PR TITLE
기타 수정사항

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
@@ -16,10 +16,15 @@ import kotlin.coroutines.resume
  * 내용: Firebase RDB의 User데이터 관리
  * */
 class FirebaseUserRemoteDataSource {
-    private fun getReference() = Firebase.database.getReference("UserData")
+    private final val REFERENCE_BLOG_SCRAP = "BlogScrap"
+    private final val REFERENCE_USER_DATA = "UserData"
+    private final val REFERENCE_NICKNAME = "NickNameData"
 
-    private fun getNickReference() = Firebase.database.getReference("NickNameData")
+    private fun getReference() = Firebase.database.getReference(REFERENCE_USER_DATA)
+    private fun getNickReference() = Firebase.database.getReference(REFERENCE_NICKNAME)
     private fun authReference() = FirebaseAuth.getInstance()
+    private fun getBlogScrapReference(uid: String) =
+        Firebase.database.getReference(REFERENCE_BLOG_SCRAP).child(uid)
 
     /**
      * 작성자 : 서정한
@@ -67,8 +72,10 @@ class FirebaseUserRemoteDataSource {
     fun withdrawalUserData(uid: String) {
         val user = authReference().currentUser
         val userRef = getReference().child(uid)
+        val blogRef = getBlogScrapReference(uid)
         user?.delete()
         userRef.removeValue()
+        blogRef.removeValue()
     }
 
     /**

--- a/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/MyPageScrapFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/mypage/scrap/MyPageScrapFragment.kt
@@ -58,8 +58,6 @@ class MyPageScrapFragment : Fragment() {
                        startActivity(intent)
                    }
                 }
-//                bookmarkResults.launch(ScrapDetail.newIntentForScrap(bookmarkContext, model))
-//                viewModel.updateBoardDataView(model.toCommunityEntity(), position)
             }
         )
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/scrap/main/ScrapFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/scrap/main/ScrapFragment.kt
@@ -1,5 +1,6 @@
 package kr.sparta.tripmate.ui.scrap.main
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -13,6 +14,9 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kr.sparta.tripmate.R
 import kr.sparta.tripmate.databinding.FragmentScrapBinding
 import kr.sparta.tripmate.ui.scrap.detail.ScrapDetailActivity
@@ -59,6 +63,9 @@ class ScrapFragment : Fragment() {
         }
 
     private val viewModel: SearchBlogViewModel by viewModels { SearchBlogFactory() }
+    private val uid by lazy {
+        SharedPreferences.getUid(scrapContext)
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -78,9 +85,11 @@ class ScrapFragment : Fragment() {
         initViewModel()
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     override fun onResume() {
         super.onResume()
         setRandomRecommandView()
+        scrapAdapter.notifyDataSetChanged()
     }
 
     private fun initView() = with(binding) {
@@ -103,11 +112,10 @@ class ScrapFragment : Fragment() {
 
                         val query = scrapSearchView.query.toString()
                         // query가 빈 값일경우 Pass
-                        if(query == "") {
+                        if (query == "") {
                             return
                         }
-
-                        viewModel.searchAPIResult(query, scrapContext)
+                        viewModel.searchAPIResult(query, uid)
                         return
                     }
                 }
@@ -122,7 +130,7 @@ class ScrapFragment : Fragment() {
             object : SearchView.OnQueryTextListener {
                 override fun onQueryTextSubmit(query: String?): Boolean {
                     query?.let {
-                        viewModel.searchAPIResult(query.trim(), scrapContext)
+                        viewModel.searchAPIResult(query.trim(), uid)
                         searchLoading = !searchLoading
                     }
                     return false

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/scrap/main/SearchBlogViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/scrap/main/SearchBlogViewModel.kt
@@ -40,13 +40,12 @@ class SearchBlogViewModel(
      * 작성자: 박성수
      * 내용: 네이버 API로 블로그 검색한 결과를 받아옴
      * */
-    fun searchAPIResult(q: String, context: Context) = viewModelScope.launch {
+    fun searchAPIResult(q: String, uid: String) = viewModelScope.launch {
         /**
          * 작성자: 서정한
          * 내용: 검색결과에 내가 스크랩한 블로그 표시
          * */
         suspend fun applyBlogScraps(scrapItems: ArrayList<SearchBlogEntity>) {
-            val uid = SharedPreferences.getUid(context)
             getAllBlogScraps(uid).collect() { blogs ->
                 val scraps = blogs.toMutableList().toEntity()
 

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/scrap/main/SearchBlogViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/scrap/main/SearchBlogViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.scrap.ImageItemsEntity
+import kr.sparta.tripmate.domain.model.scrap.ImageServerDataEntity
 import kr.sparta.tripmate.domain.model.search.SearchBlogEntity
 import kr.sparta.tripmate.domain.model.search.toEntity
 import kr.sparta.tripmate.domain.usecase.GetImageUseCase
@@ -28,7 +29,7 @@ class SearchBlogViewModel(
     private val _isLoading = MutableLiveData<Boolean>()
 
     private val _recommandImage = MutableLiveData<List<ImageItemsEntity>>()
-    val recommandImage :LiveData<List<ImageItemsEntity>> get() = _recommandImage
+    val recommandImage: LiveData<List<ImageItemsEntity>> get() = _recommandImage
 
     val isLoading: LiveData<Boolean> get() = _isLoading
 
@@ -56,13 +57,15 @@ class SearchBlogViewModel(
                         scrapItems[i] = item.copy(
                             isLike = true
                         )
-                    }else {
+                    } else {
                         scrapItems[i] = item.copy(
                             isLike = false
                         )
                     }
                 }
-                _searchList.value = scrapItems
+                val newList = mutableListOf<SearchBlogEntity>()
+                newList.addAll(scrapItems)
+                _searchList.value = newList
 
                 // loading end
                 _isLoading.value = false
@@ -85,20 +88,15 @@ class SearchBlogViewModel(
     }
 
     fun searchImageResult(q: String) = viewModelScope.launch {
-        kotlin.runCatching {
-            _isLoading.value = true
-            val result = getImageUseCase(q)
-            val imageItems = ArrayList<ImageItemsEntity>()
-            result.items?.let {
-                for(i in it.indices){
-                    imageItems.add(it[i])
-                }
-                _recommandImage.value = imageItems
-                _isLoading.value = false
+        _isLoading.value = true
+        val result = getImageUseCase(q)
+        val imageItems = ArrayList<ImageItemsEntity>()
+        result.items?.let {
+            for(i in it.indices){
+                imageItems.add(it[i])
             }
-        }.onFailure {
+            _recommandImage.value = imageItems
             _isLoading.value = false
-            Log.e("tripmates", it.message.toString())
         }
     }
 

--- a/app/src/main/java/kr/sparta/tripmate/util/sharedpreferences/SharedPreferences.kt
+++ b/app/src/main/java/kr/sparta/tripmate/util/sharedpreferences/SharedPreferences.kt
@@ -51,8 +51,12 @@ object SharedPreferences {
 
     fun removeKey(context: Context) {
         val edit = context.getSharedPreferences(USER_KEY, Context.MODE_PRIVATE).edit()
+        edit.remove("uid")
+        edit.remove("profile")
+        edit.remove("nickName")
+        edit.remove("uidFromUser")
         edit.clear()
-        edit.commit()
+        edit.apply()
     }
 
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -119,7 +119,7 @@
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/home_scrap_recycler_view"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="120dp"
                         android:layout_marginStart="15dp"
                         android:layout_marginTop="5dp"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -183,7 +183,7 @@
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/home_board_recyclerview"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="120dp"
                         android:layout_marginStart="15dp"
                         android:layout_marginTop="5dp"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -205,7 +205,7 @@
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/budget_const"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/popular_const">
@@ -252,6 +252,7 @@
                         android:layout_marginTop="5dp"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/home_view3" />
 
                 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📌Linked Issues

## ✏Change Details

블로그 페이지
- 블로그 스크랩시 검색한 내용과 세부페이지에서 스크랩여부를 동기화하였습니다.
- 회원탈퇴시 기존회원의 블로그스크랩데이터가 삭제되도록 하였습니다.
- 회원탈퇴 및 재가입후 홈 화면에서 카드뷰의 컨텐츠들이 안보이는 현상을 보이도록 수정하였습니다.
- 회원탈퇴시 기존 기기에 저장했던 모든 유저의 정보(uid, thumbnail이미지, 닉네임)를 삭제합니다.

## 💬Comment

## 📑References

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
