### PR TITLE
커뮤니티페이지: 탈퇴유저프로필 클릭 오류수정 

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/datasource/remote/user/FirebaseUserRemoteDataSource.kt
@@ -6,6 +6,7 @@ import com.google.firebase.database.ktx.getValue
 import com.google.firebase.database.ktx.snapshots
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kr.sparta.tripmate.data.model.user.UserData
@@ -30,9 +31,9 @@ class FirebaseUserRemoteDataSource {
      * 작성자 : 서정한
      * 내용 : 유저정보를 가져옵니다.
      */
-    fun getUserData(uid: String): Flow<UserData> {
+    fun getUserData(uid: String): Flow<UserData?> {
         val ref = getReference().child(uid)
-        return ref.snapshots.mapNotNull {
+        return ref.snapshots.map {
             it.getValue<UserData>()
         }
     }

--- a/app/src/main/java/kr/sparta/tripmate/data/repository/user/FirebaseUserRepositoryImpl.kt
+++ b/app/src/main/java/kr/sparta/tripmate/data/repository/user/FirebaseUserRepositoryImpl.kt
@@ -16,7 +16,7 @@ import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
  * */
 class FirebaseUserRepositoryImpl(private val remoteSource: FirebaseUserRemoteDataSource) :
     FirebaseUserRepository {
-    override fun getUserData(uid: String): Flow<UserData> = remoteSource.getUserData(uid)
+    override fun getUserData(uid: String): Flow<UserData?> = remoteSource.getUserData(uid)
 
     override fun saveUserData(model: UserDataEntity) = remoteSource.saveUserData(model.toModel())
 

--- a/app/src/main/java/kr/sparta/tripmate/domain/repository/user/FirebaseUserRepository.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/repository/user/FirebaseUserRepository.kt
@@ -9,7 +9,7 @@ import kr.sparta.tripmate.domain.model.user.UserDataEntity
  * 내용: 유저 Repository
  * */
 interface FirebaseUserRepository {
-    fun getUserData(uid: String): Flow<UserData>
+    fun getUserData(uid: String): Flow<UserData?>
 
     fun saveUserData(model: UserDataEntity)
 

--- a/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/GetUserDataUseCase.kt
+++ b/app/src/main/java/kr/sparta/tripmate/domain/usecase/firebaseuserrepository/GetUserDataUseCase.kt
@@ -7,5 +7,5 @@ import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 
 class GetUserDataUseCase(private val repository: FirebaseUserRepository) {
 
-    operator fun invoke(uid: String): Flow<UserData> = repository.getUserData(uid)
+    operator fun invoke(uid: String): Flow<UserData?> = repository.getUserData(uid)
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/main/CommunityFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/main/CommunityFactory.kt
@@ -3,14 +3,18 @@ package kr.sparta.tripmate.ui.viewmodel.community.main
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import kr.sparta.tripmate.data.datasource.remote.community.FirebaseBoardRemoteDataSource
+import kr.sparta.tripmate.data.datasource.remote.user.FirebaseUserRemoteDataSource
 import kr.sparta.tripmate.data.repository.community.FirebaseBoardRepositoryImpl
 import kr.sparta.tripmate.data.repository.community.FirebaseBoardScrapRepositoryImpl
+import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.community.FirebaseBoardRepository
 import kr.sparta.tripmate.domain.repository.community.FirebaseBoardScrapRepository
+import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetAllBoardsUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardLikeUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardScrapUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardViewsUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
 
 class CommunityFactory : ViewModelProvider.Factory {
     private val repository : FirebaseBoardRepository by lazy {
@@ -20,6 +24,9 @@ class CommunityFactory : ViewModelProvider.Factory {
     private val boardScrapRepository: FirebaseBoardScrapRepository by lazy {
         FirebaseBoardScrapRepositoryImpl(FirebaseBoardRemoteDataSource())
     }
+    private val userDataRepository: FirebaseUserRepository by lazy{
+        FirebaseUserRepositoryImpl(FirebaseUserRemoteDataSource())
+    }
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(CommunityViewModel::class.java)) {
@@ -28,6 +35,7 @@ class CommunityFactory : ViewModelProvider.Factory {
                 GetAllBoardsUseCase(repository),
                 UpdateBoardViewsUseCase(repository),
                 UpdateBoardScrapUseCase(boardScrapRepository),
+                GetUserDataUseCase(userDataRepository),
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel Class")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/main/CommunityViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/community/main/CommunityViewModel.kt
@@ -5,19 +5,24 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kr.sparta.tripmate.domain.model.community.CommunityEntity
 import kr.sparta.tripmate.domain.model.community.toEntity
+import kr.sparta.tripmate.domain.model.user.UserDataEntity
+import kr.sparta.tripmate.domain.model.user.toEntity
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.GetAllBoardsUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardLikeUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardScrapUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseboardrepository.UpdateBoardViewsUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
 
 class CommunityViewModel(
     private val updateBoardLikeUseCase: UpdateBoardLikeUseCase,
     private val getAllBoardsUseCase: GetAllBoardsUseCase,
     private val updateBoardViewsUseCase: UpdateBoardViewsUseCase,
-    private val updateBoardScrapUseCase: UpdateBoardScrapUseCase
+    private val updateBoardScrapUseCase: UpdateBoardScrapUseCase,
+    private val getUserDataUseCase: GetUserDataUseCase,
 ) :
     ViewModel() {
 
@@ -41,6 +46,14 @@ class CommunityViewModel(
             _boards.value = it.toEntity()
         }
     }
+
+    /**
+     * 작성자: 서정한
+     * 내용: 탈퇴유저판별을위해 RDB에서 uid의 UserData를 불러옵니다.
+     * 존재하지않을경우 null을 반환합니다.
+     * */
+    fun getUserData(uid: String) = getUserDataUseCase(uid)
+
 
     fun getFilteredBoard(query:String){
         val allList = _boards.value

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/main/MyPageViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/mypage/main/MyPageViewModel.kt
@@ -22,7 +22,7 @@ class MyPageViewModel(
 
     fun getUserData(uid: String) = viewModelScope.launch {
         getUserDataUseCase(uid).collect(){
-            _userData.value = it.toEntity()
+            _userData.value = it?.toEntity()
         }
     }
 

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/setting/SettingViewModel.kt
@@ -25,7 +25,7 @@ class SettingViewModel(
 
     fun getUserData(uid: String) = viewModelScope.launch{
         getUserDataUseCase(uid).collect() {
-            _settingUserData.value = it.toEntity()
+            _settingUserData.value = it?.toEntity()
         }
     }
 

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/userproflie/UserProfileViewModel.kt
@@ -16,7 +16,7 @@ class UserProfileViewModel(private val getUserDataUseCase: GetUserDataUseCase) :
 
     fun getUserData(uid: String) =viewModelScope.launch {
         getUserDataUseCase(uid).collect() {
-            _userProfileResults.value = it.toEntity()
+            _userProfileResults.value = it?.toEntity()
         }
     }
 }


### PR DESCRIPTION
## 📌Linked Issues

- #188 

## ✏Change Details

- 커뮤니티페이지와 커뮤니티 세부정보페이지에서 탈퇴한 유저의 프로필을 클릭할경우 토스트메시지를출력하며 프로필정보페이지로 이동하지 않게하였습니다.

## 💬Comment

## 📑References

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
