### PR TITLE
가계부 과정 없을때 통계및 원금 남은금액 최신화 안되는 부분 수정

### DIFF
--- a/app/src/main/java/kr/sparta/tripmate/ui/budget/budgetdetail/procedure/BudgetDetailProcedureFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/budget/budgetdetail/procedure/BudgetDetailProcedureFragment.kt
@@ -100,6 +100,11 @@ class BudgetDetailProcedureFragment : Fragment() {
                 binding.budgetDetailStatusBalanceTextview.text = it.money.toMoneyFormat() + "원"
                 binding.budgetDetailStatusDurationTextView.text = it.startDate + " ~ " + it.endDate
             }
+            budgetFlowToLiveData.observe(viewLifecycleOwner) {
+                binding.budgetDetailStatusPrincipalTextview.text = it.money.toMoneyFormat() + "원"
+                binding.budgetDetailStatusBalanceTextview.text = it.money.toMoneyFormat() + "원"
+                binding.budgetDetailStatusDurationTextView.text = it.startDate + " ~ " + it.endDate
+            }
             procedureList.observe(viewLifecycleOwner) { list ->
                 adapter.submitList(list)
 

--- a/app/src/main/java/kr/sparta/tripmate/ui/budget/budgetdetail/statistics/BudgetDetailStatisticsFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/budget/budgetdetail/statistics/BudgetDetailStatisticsFragment.kt
@@ -169,6 +169,13 @@ class BudgetDetailStatisticsFragment : Fragment() {
 
     private fun initViewModels() {
         with(viewModel) {
+            budgetFlowToLiveData.observe(viewLifecycleOwner){
+                binding.budgetStatisticsMoneyTextview.text = it.money.toMoneyFormat() + "원"
+                binding.budgetStatisticsRemainTextview.text = it.money.toMoneyFormat() + "원"
+                binding.budgetStatisticsDurationTextview.text =
+                    it.startDate + " ~ " + it.endDate
+            }
+
             budgetTotal.observe(viewLifecycleOwner) { budgetTotal ->
                 val budget: Budget = budgetTotal.first
                 val categories: List<Category> = budgetTotal.second
@@ -298,7 +305,7 @@ class BudgetDetailStatisticsFragment : Fragment() {
                 }
 
                 binding.budgetStatisticsDurationTextview.text =
-                    budget.startDate + "~" + budget.endDate
+                    budget.startDate + " ~ " + budget.endDate
                 binding.budgetStatisticsMoneyTextview.text = budget.money.toMoneyFormat() + "원"
                 binding.budgetStatisticsExpenditureTextview.text =
                     totalExpenditureSum.toMoneyFormat() + "원"

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/budget/budgetdetail/statistics/BudgetStatisticsFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/budget/budgetdetail/statistics/BudgetStatisticsFactory.kt
@@ -3,12 +3,23 @@ package kr.sparta.tripmate.ui.viewmodel.budget.budgetdetail.statistics
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import kr.sparta.tripmate.data.datasource.local.budget.BudgetCategoriesLocalDataSource
+import kr.sparta.tripmate.data.datasource.local.budget.BudgetLocalDataSource
+import kr.sparta.tripmate.data.datasource.local.budget.CategoryProceduresLocalDataSource
 import kr.sparta.tripmate.data.datasource.local.budget.ProcedureLocalDataSource
+import kr.sparta.tripmate.data.repository.budget.BudgetRepositoryImpl
 import kr.sparta.tripmate.data.repository.budget.BudgetTotalRepositoryImpl
+import kr.sparta.tripmate.domain.usecase.budgetrepository.GetBudgetToFlowWhenBudgetChangedWithNumUseCase
 import kr.sparta.tripmate.domain.usecase.budgettotalrepository.GetBudgetTotalToFlowWhenProccessChangedWithBudgetNumUseCase
 import kr.sparta.tripmate.util.TripMateApp
 
 class BudgetStatisticsFactory(val budgetNum: Int) : ViewModelProvider.Factory {
+    private val budgetRepository by lazy {
+        BudgetRepositoryImpl(
+            BudgetLocalDataSource(TripMateApp.getApp().applicationContext),
+            ProcedureLocalDataSource(TripMateApp.getApp().applicationContext),
+            CategoryProceduresLocalDataSource(TripMateApp.getApp().applicationContext),
+        )
+    }
     private val budgetTotalRepository by lazy {
         BudgetTotalRepositoryImpl(
             ProcedureLocalDataSource(TripMateApp.getApp().applicationContext),
@@ -19,6 +30,7 @@ class BudgetStatisticsFactory(val budgetNum: Int) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(BudgetStatisticsViewModel::class.java)) {
             return BudgetStatisticsViewModel(
+                GetBudgetToFlowWhenBudgetChangedWithNumUseCase(budgetRepository),
                 GetBudgetTotalToFlowWhenProccessChangedWithBudgetNumUseCase(budgetTotalRepository),
                 budgetNum
             ) as T

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/budget/budgetdetail/statistics/BudgetStatisticsViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/budget/budgetdetail/statistics/BudgetStatisticsViewModel.kt
@@ -4,20 +4,30 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import kr.sparta.tripmate.data.model.budget.Budget
 import kr.sparta.tripmate.data.model.budget.Category
 import kr.sparta.tripmate.data.model.budget.Procedure
 import kr.sparta.tripmate.data.model.budget.toModel
+import kr.sparta.tripmate.domain.usecase.budgetrepository.GetBudgetToFlowWhenBudgetChangedWithNumUseCase
 import kr.sparta.tripmate.domain.usecase.budgettotalrepository.GetBudgetTotalToFlowWhenProccessChangedWithBudgetNumUseCase
 import kr.sparta.tripmate.ui.budget.budgetdetail.procedure.ProcedureModel
 
 class BudgetStatisticsViewModel(
+    private val getBudgetToFlowWhenBudgetChangedWithNumUseCase: GetBudgetToFlowWhenBudgetChangedWithNumUseCase,
     getBudgetTotalToFlowWhenProccessChangedWithBudgetNumUseCase: GetBudgetTotalToFlowWhenProccessChangedWithBudgetNumUseCase,
-    budgetNum: Int,
+    private val budgetNum: Int,
 ) : ViewModel() {
     private val _budgetLiveData: MutableLiveData<Budget> = MutableLiveData()
     val budgetLiveData get() = _budgetLiveData
+
+    val budgetFlowToLiveData =
+        getBudgetToFlowWhenBudgetChangedWithNumUseCase(budgetNum).flatMapConcat {
+            flow {
+                if (procedureList.value.orEmpty().isEmpty()) emit(it)
+            }
+        }.asLiveData()
 
     private val _procedureList: MutableLiveData<List<ProcedureModel>> = MutableLiveData()
     val procedureList get() = _procedureList


### PR DESCRIPTION
## **가계부 : 정 없을때 통계및 원금 남은금액 최신화 안되는 부분 수정**

## 📌Linked Issues

- #211 

## ✏Change Details

- viewmodel에 usecase를 추가하여 budget의 변경을 감지
- 과정이 없을때만 받아오게 수정
- fragment에서 observe 필요한 UI만 수정

## 💬Comment

## 📑References

## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
