### PR TITLE
1.0.4버전 : Login&splash&setting&budget&scrap : Bug, Feat, Ui를 수정 했습니다. 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "kr.sparta.tripmate"
         minSdk = 31
         targetSdk = 33
-        versionCode = 5
-        versionName = "1.0.3"
+        versionCode = 6
+        versionName = "1.0.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,4 +109,8 @@ dependencies {
 
     //addmob
     implementation("com.google.android.gms:play-services-ads:22.5.0")
+
+    //google play store
+    implementation("com.google.android.play:app-update-ktx:2.1.0")
+    implementation("com.google.android.play:app-update:2.1.0")
 }

--- a/app/src/main/java/kr/sparta/tripmate/api/Constants.kt
+++ b/app/src/main/java/kr/sparta/tripmate/api/Constants.kt
@@ -8,5 +8,4 @@ object Constants {
     var EMPTYTYPE = 0
     var SCRAPTYPE = 1
     var COMMUNITYTYPE = 2
-    var LatestVersionCode = 5
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/budget/procedurecontent/ProcedureContentActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/budget/procedurecontent/ProcedureContentActivity.kt
@@ -94,7 +94,7 @@ class ProcedureContentActivity : AppCompatActivity() {
     private fun setEditTextView() = with(binding) {
         procedureMoneyEdittext.setMaxLength(13)
         procedureNameEdittext.setMaxLength(19)
-        procedureMemoEdittext.setMaxLength(100)
+        procedureMemoEdittext.setMaxLength(99)
     }
 
     private fun initViewModels() {

--- a/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/home/HomeFragment.kt
@@ -25,6 +25,7 @@ import kr.sparta.tripmate.ui.viewmodel.home.main.HomeFactory
 import kr.sparta.tripmate.ui.viewmodel.home.main.HomeViewModel
 import kr.sparta.tripmate.ui.viewmodel.home.scrap.HomeBlogScrapFactory
 import kr.sparta.tripmate.ui.viewmodel.home.scrap.HomeBlogScrapViewModel
+import kr.sparta.tripmate.util.method.shortToast
 
 class HomeFragment : Fragment() {
     companion object {
@@ -103,6 +104,7 @@ class HomeFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
+        homeContext.shortToast("${homeViewModel.getNickName()} 의 계정으로 로그인 되었습니다.")
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
     }

--- a/app/src/main/java/kr/sparta/tripmate/ui/setting/SettingActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/setting/SettingActivity.kt
@@ -1,11 +1,13 @@
 package kr.sparta.tripmate.ui.setting
 
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import coil.load
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.MobileAds
@@ -114,5 +116,30 @@ class SettingActivity : AppCompatActivity() {
         MobileAds.initialize(this)
         val adRequest = AdRequest.Builder().build()
         binding.settingAdsBanner.loadAd(adRequest)
+    }
+    override fun onBackPressed() {
+        val builder = AlertDialog.Builder(this@SettingActivity)
+        builder.setTitle("앱 종료")
+        builder.setMessage("앱을 종료하시겠습니까?")
+        val listener = DialogInterface.OnClickListener { p0, p1 ->
+            when (p1) {
+                DialogInterface.BUTTON_POSITIVE -> {
+                    super.onBackPressed()
+                }
+
+                DialogInterface.BUTTON_NEGATIVE -> {}
+            }
+        }
+
+        builder.setPositiveButton(
+            getString(R.string.budget_detail_dialog_positive_text),
+            listener
+        )
+        builder.setNegativeButton(
+            getString(R.string.budget_detail_dialog_negative_text),
+            listener
+        )
+
+        builder.show()
     }
 }

--- a/app/src/main/java/kr/sparta/tripmate/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/splash/SplashActivity.kt
@@ -9,6 +9,9 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import androidx.appcompat.app.AlertDialog
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.UpdateAvailability
 import kr.sparta.tripmate.BuildConfig
 import kr.sparta.tripmate.R
 import kr.sparta.tripmate.api.Constants
@@ -45,38 +48,39 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun updateCheck(){
-        val latestVersionCode = Constants.LatestVersionCode
-        val currentVersionCode = BuildConfig.VERSION_CODE
+        val appUpdateManager = AppUpdateManagerFactory.create(this)
+        val appUpdateInfoTask = appUpdateManager.appUpdateInfo
+        appUpdateInfoTask.addOnSuccessListener { appUpdateInfo ->
+            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(
+                    AppUpdateType.IMMEDIATE)) {
+                val builder = AlertDialog.Builder(this@SplashActivity)
+                builder.setTitle("업데이트")
+                builder.setMessage("최신 버전이 있습니다. \n 업데이트를 해주세요")
+                val listener = DialogInterface.OnClickListener { p0, p1 ->
+                    when (p1) {
+                        DialogInterface.BUTTON_POSITIVE -> {
+                            updateVersionCheck()
+                            super.onBackPressed()
+                        }
 
-        if (currentVersionCode < latestVersionCode) {
-
-            val builder = AlertDialog.Builder(this@SplashActivity)
-            builder.setTitle("업데이트")
-            builder.setMessage("최신 버전이 있습니다. \n 업데이트를 해주세요")
-            val listener = DialogInterface.OnClickListener { p0, p1 ->
-                when (p1) {
-                    DialogInterface.BUTTON_POSITIVE -> {
-                        updateVersionCheck()
-                        super.onBackPressed()
-                    }
-
-                    DialogInterface.BUTTON_NEGATIVE -> {
-                        super.onBackPressed()
+                        DialogInterface.BUTTON_NEGATIVE -> {
+                            super.onBackPressed()
+                        }
                     }
                 }
+                builder.setPositiveButton(
+                    getString(R.string.budget_detail_dialog_positive_text),
+                    listener
+                )
+                builder.setNegativeButton(
+                    getString(R.string.budget_detail_dialog_negative_text),
+                    listener
+                )
+                builder.setCancelable(false)
+                builder.show()
+            } else {
+                startSplash()
             }
-            builder.setPositiveButton(
-                getString(R.string.budget_detail_dialog_positive_text),
-                listener
-            )
-            builder.setNegativeButton(
-                getString(R.string.budget_detail_dialog_negative_text),
-                listener
-            )
-            builder.setCancelable(false)
-            builder.show()
-        } else {
-            startSplash()
         }
     }
     private fun updateVersionCheck() {

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginFactory.kt
@@ -9,6 +9,7 @@ import kr.sparta.tripmate.data.repository.user.FirebaseUserRepositoryImpl
 import kr.sparta.tripmate.domain.repository.sharedpreference.SharedPreferenceReopository
 import kr.sparta.tripmate.domain.repository.user.FirebaseUserRepository
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetNickNameDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.WithdrawalUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.sharedpreference.GetNickNameUseCase
@@ -37,7 +38,8 @@ class LoginFactory : ViewModelProvider.Factory {
                 SaveNickNameUseCase(sharedPreferenceReopository),
                 GetUidUseCase(sharedPreferenceReopository),
                 GetNickNameUseCase(sharedPreferenceReopository),
-                WithdrawalUserDataUseCase(firebaseUserRepository)
+                WithdrawalUserDataUseCase(firebaseUserRepository),
+                GetUserDataUseCase(firebaseUserRepository)
             ) as T
         }
         throw IllegalArgumentException("에러")

--- a/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
+++ b/app/src/main/java/kr/sparta/tripmate/ui/viewmodel/login/LoginViewModel.kt
@@ -7,6 +7,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import kr.sparta.tripmate.domain.model.user.UserDataEntity
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetNickNameDataUseCase
+import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.GetUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.SaveUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.firebaseuserrepository.WithdrawalUserDataUseCase
 import kr.sparta.tripmate.domain.usecase.sharedpreference.GetNickNameUseCase
@@ -23,7 +24,8 @@ class LoginViewModel(
     private val saveNickNameUseCase: SaveNickNameUseCase,
     private val getUidUseCase: GetUidUseCase,
     private val getNickNameUseCase: GetNickNameUseCase,
-    private val withdrawalUserDataUseCase: WithdrawalUserDataUseCase
+    private val withdrawalUserDataUseCase: WithdrawalUserDataUseCase,
+    private val getUserDataUseCase: GetUserDataUseCase
 ) :
     ViewModel() {
     private val auth = FirebaseAuth.getInstance()
@@ -50,4 +52,6 @@ class LoginViewModel(
     fun getNickName(): String = getNickNameUseCase()
 
     fun removeUserData(uid: String) = withdrawalUserDataUseCase(uid)
+
+    fun getUserData(uid: String) = getUserDataUseCase(uid)
 }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -78,6 +78,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="20dp"
                 android:gravity="center"
+                android:singleLine="true"
                 android:layout_marginTop="50dp"
                 android:hint="@string/nick_title"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -112,5 +113,18 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/login_progressbar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:clickable="false"
+        android:visibility="gone"
+        android:indeterminateTint="@color/primary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/homebudgetitem.xml
+++ b/app/src/main/res/layout/homebudgetitem.xml
@@ -48,7 +48,7 @@
 
             <TextView
                 android:id="@+id/home_budget_amount"
-                android:layout_width="wrap_content"
+                android:layout_width="65dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
                 android:text="원금"
@@ -68,7 +68,7 @@
                 android:maxLines="1"
                 android:textAlignment="textEnd"
                 android:textColor="@color/black"
-                android:textSize="15sp"
+                android:textSize="14sp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/home_budget_amount"
@@ -86,7 +86,7 @@
 
             <TextView
                 android:id="@+id/home_remain_budget_text"
-                android:layout_width="wrap_content"
+                android:layout_width="65dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="15dp"
                 android:text="남은 예산"
@@ -106,7 +106,7 @@
                 android:maxLines="1"
                 android:textAlignment="textEnd"
                 android:textColor="@color/black"
-                android:textSize="15sp"
+                android:textSize="14sp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/scraptitems.xml
+++ b/app/src/main/res/layout/scraptitems.xml
@@ -37,6 +37,7 @@
         android:textColor="@color/black"
         android:textSize="15sp"
         android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/scrap_type_iconCardView"
         tools:text="테스틈ㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㄹ" />


### PR DESCRIPTION
## 📌Linked Issues

- 

## ✏Change Details

### BUG
- login : 닉네임 입력 시 무한 엔터 되던 부분 수정했습니다.
- login : 회원탈퇴를 하지않고 앱을 삭제 후 재 설치 했을때 발생했던 에러를 수정했습니다.

### FEAT
- splash : 구글스토어에 업데이트가 있는지 확인하고, 업데이트가 있다면 업데이트하고, 그렇지 않으면 바로 접속됩니다.
- 접속했을때 토스트메시지를 추가했습니다.
- setting : 시스템 뒤로가기를 눌렀을때 종료 다이얼로그를 추가했습니다.

### UI
- 가계부 과정 : 메모 최대글자수를 99자까지 수정했습니다.
- home : 가계부 관련 텍스트 정렬이 쏠리는 부분 수정했습니다. 
- scrap : 텍스트가 좌측으로 쏠리는 부분 수정했습니다.
- 
## 💬Comment

- 해당 PR 살펴볼시 참고하면 좋을 사항들을 기록하기.
- 참고사항이 없을경우 기록하지 않아도 무방.

## 📑References


## ✅Check List

- [x]  추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x]  코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
